### PR TITLE
Feat/channel partners

### DIFF
--- a/suntek_app/channel_partner/doctype/channel_partner/channel_partner.js
+++ b/suntek_app/channel_partner/doctype/channel_partner/channel_partner.js
@@ -1,96 +1,78 @@
 frappe.ui.form.on("Channel Partner", {
-	refresh(frm) {
-		if (frm.doc.status === "Active" && !frm.doc.is_user_created && frm.doc.suntek_email) {
-			frm.add_custom_button(__("Create User"), function () {
-				frm.call({
-					doc: frm.doc,
-					method: "create_user",
-					callback: function (r) {
-						if (r.message) {
-							frappe.show_alert({
-								message: __("User created and linked successfully"),
-								indicator: "green",
-							});
-							frm.reload_doc();
-						}
-					},
-				});
-			});
-		}
+  refresh(frm) {
+    if (
+      frm.doc.status === "Active" &&
+      !frm.doc.is_user_created &&
+      frm.doc.suntek_email
+    ) {
+      frm.add_custom_button(__("Create User"), function () {
+        frm.call({
+          doc: frm.doc,
+          method: "create_user",
+          callback: function (r) {
+            if (r.message) {
+              frappe.show_alert({
+                message: __("User created and linked successfully"),
+                indicator: "green",
+              });
+              frm.reload_doc();
+            }
+          },
+        });
+      });
+    }
+  },
 
-		if (frm.doc.status === "Active" && !frm.doc.__is_local && !frm.doc.linked_customer) {
-			// frm.add_custom_button(__("Create Customer"), function () {
-			//   frm.call({
-			//     doc: frm.doc,
-			//     method: "create_customer",
-			//     callbacl: function (r) {
-			//       if (r.message) {
-			//         frappe.show_alert({
-			//           message: __("Customer created successfully"),
-			//           indicator: "green",
-			//         });
-			//         frm.reload_doc();
-			//       }
-			//     },
-			//   });
-			// });
-		}
-
-		if (frm.doc.status === "Active" && frm.doc.is_user_created && !frm.doc.warehouse) {
-			// frm.add_custom_button(__("Create Warehouse"), function () {
-			//   frm.call({
-			//     doc: frm.doc,
-			//     method: "create_channel_partner_warehouse",
-			//     callback: function (r) {
-			//       if (r.message) {
-			//         frappe.show_alert({
-			//           message: __("Warehouse created successfully"),
-			//           indicator: "green",
-			//         });
-			//         frm.reload_doc();
-			//       }
-			//     },
-			//   });
-			// });
-		}
-	},
-
-	channel_partner_firm: function (frm) {
-		// When firm changes, fetch address and contact info from firm
-		if (frm.doc.channel_partner_firm) {
-			frappe.db.get_doc("Channel Partner Firm", frm.doc.channel_partner_firm).then((firm) => {
-				// If firm has an address, suggest using it
-				if (firm.address) {
-					frappe.confirm(`Do you want to use the address from ${firm.firm_name}?`, () => {
-						// Yes, use the firm's address
-						frappe.db.get_value(
-							"Address",
-							firm.address,
-							["name", "address_line1", "address_line2", "city", "state", "country", "pincode"],
-							(r) => {
-								if (r) {
-									// Create a new address for the channel partner, linked to the same physical address
-									frm.set_value("channel_partner_address", r.name);
-								}
-							}
-						);
-					});
-				}
-			});
-		}
-	},
+  channel_partner_firm: function (frm) {
+    if (frm.doc.channel_partner_firm) {
+      frappe.db
+        .get_doc("Channel Partner Firm", frm.doc.channel_partner_firm)
+        .then((firm) => {
+          if (firm.address) {
+            frappe.confirm(
+              `Do you want to use the address from ${firm.firm_name}?`,
+              () => {
+                frappe.db.get_value(
+                  "Address",
+                  firm.address,
+                  [
+                    "name",
+                    "address_line1",
+                    "address_line2",
+                    "city",
+                    "state",
+                    "country",
+                    "pincode",
+                  ],
+                  (r) => {
+                    if (r) {
+                      frm.set_value("channel_partner_address", r.name);
+                    }
+                  }
+                );
+              }
+            );
+          }
+        });
+    }
+  },
 });
 
 frappe.ui.form.on("District PIN Code Table", {
-	pin_code: function (frm, cdt, cdn) {
-		let row = locals[cdt][cdn];
-		if (row.pin_code) {
-			frappe.db.get_value("District PIN Code", row.pin_code, ["district", "city"], (response) => {
-				if (response) {
-					frappe.model.set_value(cdt, cdn, "district", response.district);
-					frappe.model.set_value(cdt, cdn, "city", response.city);
-				}
-			});
-		}
-	},
+  pin_code: function (frm, cdt, cdn) {
+    let row = locals[cdt][cdn];
+    if (row.pin_code) {
+      frappe.db.get_value(
+        "District PIN Code",
+        row.pin_code,
+        ["district", "city"],
+        (response) => {
+          if (response) {
+            frappe.model.set_value(cdt, cdn, "district", response.district);
+            frappe.model.set_value(cdt, cdn, "city", response.city);
+          }
+        }
+      );
+    }
+  },
 });

--- a/suntek_app/channel_partner/doctype/channel_partner/channel_partner.json
+++ b/suntek_app/channel_partner/doctype/channel_partner/channel_partner.json
@@ -1,547 +1,551 @@
 {
-    "actions": [],
-    "allow_rename": 1,
-    "creation": "2025-02-05 15:27:37.646348",
-    "default_view": "List",
-    "doctype": "DocType",
-    "engine": "InnoDB",
-    "field_order": [
-        "salutation",
-        "first_name",
-        "last_name",
-        "channel_partner_firm",
-        "channel_partner_customer",
-        "channel_partner_name",
-        "channel_partner_code",
-        "contact_person",
-        "email",
-        "mobile_number",
-        "alternate_number",
-        "column_break_jjiy",
-        "credit_limit",
-        "status",
-        "is_exclusive",
-        "is_experienced",
-        "is_user_created",
-        "suntek_mobile_number",
-        "suntek_email",
-        "linked_user",
-        "linked_customer",
-        "section_break_zuam",
-        "contact",
-        "channel_partner_address",
-        "address",
-        "address_line_2",
-        "column_break_gcmk",
-        "district",
-        "district_name",
-        "country",
-        "state",
-        "state_code",
-        "city",
-        "district_snake_case",
-        "dashboard_tab",
-        "dashboard_html",
-        "past_experience_tab",
-        "past_experience_section",
-        "past_experience",
-        "attachments_tab",
-        "personal_kyc_section",
-        "pan_number",
-        "id_proof",
-        "pan_card",
-        "column_break_sjnq",
-        "photograph",
-        "electricity_bill",
-        "section_break_zker",
-        "other_documents",
-        "pin_codes_tab",
-        "associated_pin_codes",
-        "selling_tab",
-        "warehouses_section",
-        "default_sales_warehouse",
-        "column_break_gixt",
-        "default_subsidy_warehouse",
-        "price_list_section",
-        "default_selling_list",
-        "column_break_vism",
-        "default_buying_list",
-        "connections_tab"
-    ],
-    "fields": [
-        {
-            "fieldname": "salutation",
-            "fieldtype": "Link",
-            "label": "Salutation",
-            "options": "Salutation"
-        },
-        {
-            "fieldname": "first_name",
-            "fieldtype": "Data",
-            "label": "First Name",
-            "reqd": 1
-        },
-        {
-            "fieldname": "last_name",
-            "fieldtype": "Data",
-            "label": "Last Name"
-        },
-        {
-            "fieldname": "channel_partner_firm",
-            "fieldtype": "Link",
-            "label": "Channel Partner Firm",
-            "options": "Channel Partner Firm",
-            "reqd": 1
-        },
-        {
-            "fieldname": "channel_partner_name",
-            "fieldtype": "Data",
-            "in_list_view": 1,
-            "label": "Channel Partner Name",
-            "read_only": 1
-        },
-        {
-            "fieldname": "channel_partner_code",
-            "fieldtype": "Data",
-            "in_global_search": 1,
-            "label": "Channel Partner Code",
-            "read_only": 1,
-            "unique": 1
-        },
-        {
-            "fieldname": "contact_person",
-            "fieldtype": "Data",
-            "label": "Contact Person"
-        },
-        {
-            "fieldname": "email",
-            "fieldtype": "Data",
-            "label": "Email",
-            "reqd": 1
-        },
-        {
-            "fieldname": "mobile_number",
-            "fieldtype": "Data",
-            "in_list_view": 1,
-            "label": "Mobile Number",
-            "reqd": 1
-        },
-        {
-            "fieldname": "alternate_number",
-            "fieldtype": "Data",
-            "label": "Alternate Number"
-        },
-        {
-            "fieldname": "pan_number",
-            "fieldtype": "Data",
-            "label": "PAN Number",
-            "reqd": 1
-        },
-        {
-            "fieldname": "column_break_jjiy",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "credit_limit",
-            "fieldtype": "Currency",
-            "label": "Credit Limit"
-        },
-        {
-            "default": "Pending Approval",
-            "fieldname": "status",
-            "fieldtype": "Select",
-            "label": "Status",
-            "options": "\nActive\nInactive\nPending Approval",
-            "reqd": 1
-        },
-        {
-            "default": "0",
-            "fieldname": "is_exclusive",
-            "fieldtype": "Check",
-            "label": "Is Exclusive"
-        },
-        {
-            "default": "0",
-            "fieldname": "is_experienced",
-            "fieldtype": "Check",
-            "label": "Is Experienced"
-        },
-        {
-            "default": "0",
-            "fieldname": "is_user_created",
-            "fieldtype": "Check",
-            "label": "Is User Created",
-            "read_only": 1
-        },
-        {
-            "depends_on": "eval:doc.status==\"Active\"",
-            "fieldname": "suntek_mobile_number",
-            "fieldtype": "Data",
-            "label": "Suntek Mobile Number",
-            "mandatory_depends_on": "eval:doc.status==\"Active\""
-        },
-        {
-            "depends_on": "eval:doc.status==\"Active\"",
-            "fieldname": "suntek_email",
-            "fieldtype": "Data",
-            "label": "Suntek Email",
-            "mandatory_depends_on": "eval:doc.status==\"Active\""
-        },
-        {
-            "fieldname": "linked_user",
-            "fieldtype": "Link",
-            "label": "Linked User",
-            "options": "User",
-            "read_only": 1
-        },
-        {
-            "fieldname": "section_break_zuam",
-            "fieldtype": "Section Break"
-        },
-        {
-            "fieldname": "contact",
-            "fieldtype": "Link",
-            "label": "Contact",
-            "options": "Contact",
-            "reqd": 1
-        },
-        {
-            "fetch_from": "dealer_address.address_line1",
-            "fieldname": "address",
-            "fieldtype": "Small Text",
-            "label": "Address Line 1",
-            "read_only": 1
-        },
-        {
-            "fetch_from": "dealer_address.address_line2",
-            "fieldname": "address_line_2",
-            "fieldtype": "Small Text",
-            "label": "Address Line 2",
-            "read_only": 1
-        },
-        {
-            "fieldname": "column_break_gcmk",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "district",
-            "fieldtype": "Link",
-            "label": "District",
-            "options": "District",
-            "reqd": 1
-        },
-        {
-            "fetch_from": "district.country",
-            "fieldname": "country",
-            "fieldtype": "Data",
-            "label": "Country",
-            "read_only": 1
-        },
-        {
-            "fetch_from": "district.state",
-            "fieldname": "state",
-            "fieldtype": "Data",
-            "label": "State",
-            "read_only": 1
-        },
-        {
-            "fetch_from": "district.state_code",
-            "fieldname": "state_code",
-            "fieldtype": "Data",
-            "label": "State Code",
-            "read_only": 1
-        },
-        {
-            "fetch_from": "district.city",
-            "fieldname": "city",
-            "fieldtype": "Data",
-            "label": "City",
-            "read_only": 1
-        },
-        {
-            "fetch_from": "district.district_snake_case",
-            "fieldname": "district_snake_case",
-            "fieldtype": "Data",
-            "label": "District Snake Case",
-            "read_only": 1
-        },
-        {
-            "depends_on": "eval:doc.is_experienced == 1",
-            "fieldname": "past_experience_tab",
-            "fieldtype": "Tab Break",
-            "label": "Past Experience"
-        },
-        {
-            "fieldname": "past_experience_section",
-            "fieldtype": "Section Break",
-            "label": "Past Experience"
-        },
-        {
-            "fieldname": "past_experience",
-            "fieldtype": "Table",
-            "label": "Past Experience",
-            "mandatory_depends_on": "eval:doc.is_experienced == 1",
-            "options": "Past Experience"
-        },
-        {
-            "fieldname": "attachments_tab",
-            "fieldtype": "Tab Break",
-            "label": "Attachments"
-        },
-        {
-            "fieldname": "personal_kyc_section",
-            "fieldtype": "Section Break",
-            "label": "Personal KYC"
-        },
-        {
-            "fieldname": "id_proof",
-            "fieldtype": "Attach",
-            "label": "Aadhar Card",
-            "reqd": 1
-        },
-        {
-            "fieldname": "pan_card",
-            "fieldtype": "Attach",
-            "label": "PAN Card",
-            "reqd": 1
-        },
-        {
-            "fieldname": "column_break_sjnq",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "photograph",
-            "fieldtype": "Attach Image",
-            "label": "Photograph",
-            "reqd": 1
-        },
-        {
-            "fieldname": "electricity_bill",
-            "fieldtype": "Attach",
-            "label": "Electricity Bill",
-            "reqd": 1
-        },
-        {
-            "fieldname": "section_break_zker",
-            "fieldtype": "Section Break",
-            "label": "Additional Attachments"
-        },
-        {
-            "fieldname": "other_documents",
-            "fieldtype": "Table",
-            "label": "Other Documents",
-            "options": "Additional Attachments"
-        },
-        {
-            "fieldname": "pin_codes_tab",
-            "fieldtype": "Tab Break",
-            "label": "PIN Codes"
-        },
-        {
-            "fieldname": "associated_pin_codes",
-            "fieldtype": "Table",
-            "label": "Associated PIN Codes",
-            "options": "District PIN Code Table"
-        },
-        {
-            "fieldname": "connections_tab",
-            "fieldtype": "Tab Break",
-            "label": "Connections",
-            "show_dashboard": 1
-        },
-        {
-            "fieldname": "dashboard_tab",
-            "fieldtype": "Tab Break",
-            "label": "Dashboard"
-        },
-        {
-            "fieldname": "dashboard_html",
-            "fieldtype": "HTML",
-            "label": "Dashboard HTML"
-        },
-        {
-            "fieldname": "channel_partner_address",
-            "fieldtype": "Link",
-            "label": "Channel Partner Address",
-            "options": "Address",
-            "reqd": 1
-        },
-        {
-            "fetch_from": "district.district",
-            "fieldname": "district_name",
-            "fieldtype": "Data",
-            "label": "District Name",
-            "read_only": 1
-        },
-        {
-            "fieldname": "linked_customer",
-            "fieldtype": "Link",
-            "label": "Linked Customer",
-            "options": "Customer",
-            "read_only": 1
-        },
-        {
-            "fieldname": "default_sales_warehouse",
-            "fieldtype": "Link",
-            "label": "Default Sales Warehouse",
-            "options": "Warehouse"
-        },
-        {
-            "fieldname": "default_subsidy_warehouse",
-            "fieldtype": "Link",
-            "label": "Default Subsidy Warehouse",
-            "options": "Warehouse"
-        },
-        {
-            "fieldname": "selling_tab",
-            "fieldtype": "Tab Break",
-            "label": "Selling"
-        },
-        {
-            "fieldname": "warehouses_section",
-            "fieldtype": "Section Break",
-            "label": "Warehouses"
-        },
-        {
-            "fieldname": "column_break_gixt",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "price_list_section",
-            "fieldtype": "Section Break",
-            "label": "Price List"
-        },
-        {
-            "fieldname": "default_selling_list",
-            "fieldtype": "Link",
-            "label": "Default Selling List",
-            "options": "Price List"
-        },
-        {
-            "fieldname": "column_break_vism",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "default_buying_list",
-            "fieldtype": "Link",
-            "label": "Default Buying List",
-            "options": "Price List"
-        },
-        {
-            "fetch_from": "channel_partner_firm.customer",
-            "fieldname": "channel_partner_customer",
-            "fieldtype": "Link",
-            "label": "Channel Partner Customer",
-            "options": "Customer"
-        }
-    ],
-    "index_web_pages_for_search": 1,
-    "links": [
-        {
-            "link_doctype": "Lead",
-            "link_fieldname": "custom_channel_partner"
-        },
-        {
-            "link_doctype": "Opportunity",
-            "link_fieldname": "custom_channel_partner"
-        },
-        {
-            "link_doctype": "Quotation",
-            "link_fieldname": "custom_channel_partner"
-        },
-        {
-            "link_doctype": "Sales Order",
-            "link_fieldname": "custom_channel_partner"
-        },
-        {
-            "link_doctype": "Site Survey",
-            "link_fieldname": "channel_partner"
-        },
-        {
-            "link_doctype": "Sales Invoice",
-            "link_fieldname": "custom_channel_partner"
-        },
-        {
-            "link_doctype": "Project",
-            "link_fieldname": "custom_channel_partner"
-        },
-        {
-            "link_doctype": "Designing",
-            "link_fieldname": "channel_partner"
-        },
-        {
-            "link_doctype": "BOM",
-            "link_fieldname": "custom_channel_partner"
-        },
-        {
-            "link_doctype": "Discom",
-            "link_fieldname": "channel_partner"
-        },
-        {
-            "link_doctype": "Subsidy",
-            "link_fieldname": "channel_partner"
-        },
-        {
-            "link_doctype": "Channel Partner Purchase Order",
-            "link_fieldname": "channel_partner"
-        }
-    ],
-    "modified": "2025-03-29 11:36:57.514267",
-    "modified_by": "Administrator",
-    "module": "Channel Partner",
-    "name": "Channel Partner",
-    "naming_rule": "By script",
-    "owner": "Administrator",
-    "permissions": [
-        {
-            "create": 1,
-            "delete": 1,
-            "email": 1,
-            "export": 1,
-            "print": 1,
-            "read": 1,
-            "report": 1,
-            "role": "System Manager",
-            "select": 1,
-            "share": 1,
-            "write": 1
-        },
-        {
-            "email": 1,
-            "export": 1,
-            "print": 1,
-            "read": 1,
-            "report": 1,
-            "role": "Channel Partner Manager",
-            "select": 1,
-            "share": 0,
-            "write": 0
-        },
-        {
-            "email": 1,
-            "export": 1,
-            "print": 1,
-            "read": 1,
-            "report": 1,
-            "role": "Channel Partner",
-            "select": 1,
-            "share": 0,
-            "write": 0
-        }
-    ],
-    "search_fields": "channel_partner_name",
-    "show_name_in_global_search": 1,
-    "sort_field": "modified",
-    "sort_order": "DESC",
-    "states": [
-        {
-            "color": "Green",
-            "title": "Enabled"
-        },
-        {
-            "color": "Red",
-            "title": "Disabled"
-        }
-    ],
-    "title_field": "channel_partner_name"
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-02-05 15:27:37.646348",
+ "default_view": "List",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "salutation",
+  "first_name",
+  "last_name",
+  "channel_partner_firm",
+  "channel_partner_customer",
+  "channel_partner_name",
+  "channel_partner_code",
+  "contact_person",
+  "email",
+  "mobile_number",
+  "alternate_number",
+  "column_break_jjiy",
+  "credit_limit",
+  "status",
+  "is_exclusive",
+  "is_experienced",
+  "is_user_created",
+  "suntek_mobile_number",
+  "suntek_email",
+  "linked_user",
+  "linked_customer",
+  "section_break_zuam",
+  "contact",
+  "channel_partner_address",
+  "address",
+  "address_line_2",
+  "column_break_gcmk",
+  "district",
+  "district_name",
+  "country",
+  "state",
+  "state_code",
+  "city",
+  "district_snake_case",
+  "territory",
+  "dashboard_tab",
+  "dashboard_html",
+  "past_experience_tab",
+  "past_experience_section",
+  "past_experience",
+  "attachments_tab",
+  "personal_kyc_section",
+  "pan_number",
+  "id_proof",
+  "pan_card",
+  "column_break_sjnq",
+  "photograph",
+  "electricity_bill",
+  "section_break_zker",
+  "other_documents",
+  "pin_codes_tab",
+  "associated_pin_codes",
+  "selling_tab",
+  "warehouses_section",
+  "default_sales_warehouse",
+  "column_break_gixt",
+  "default_subsidy_warehouse",
+  "price_list_section",
+  "default_selling_list",
+  "column_break_vism",
+  "default_buying_list",
+  "connections_tab"
+ ],
+ "fields": [
+  {
+   "fieldname": "salutation",
+   "fieldtype": "Link",
+   "label": "Salutation",
+   "options": "Salutation"
+  },
+  {
+   "fieldname": "first_name",
+   "fieldtype": "Data",
+   "label": "First Name",
+   "reqd": 1
+  },
+  {
+   "fieldname": "last_name",
+   "fieldtype": "Data",
+   "label": "Last Name"
+  },
+  {
+   "fieldname": "channel_partner_firm",
+   "fieldtype": "Link",
+   "label": "Channel Partner Firm",
+   "options": "Channel Partner Firm",
+   "reqd": 1
+  },
+  {
+   "fieldname": "channel_partner_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Channel Partner Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "channel_partner_code",
+   "fieldtype": "Data",
+   "in_global_search": 1,
+   "label": "Channel Partner Code",
+   "read_only": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "contact_person",
+   "fieldtype": "Data",
+   "label": "Contact Person"
+  },
+  {
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "label": "Email",
+   "reqd": 1
+  },
+  {
+   "fieldname": "mobile_number",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Mobile Number",
+   "reqd": 1
+  },
+  {
+   "fieldname": "alternate_number",
+   "fieldtype": "Data",
+   "label": "Alternate Number"
+  },
+  {
+   "fieldname": "pan_number",
+   "fieldtype": "Data",
+   "label": "PAN Number",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_jjiy",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "credit_limit",
+   "fieldtype": "Currency",
+   "label": "Credit Limit"
+  },
+  {
+   "default": "Pending Approval",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "\nActive\nInactive\nPending Approval",
+   "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_exclusive",
+   "fieldtype": "Check",
+   "label": "Is Exclusive"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_experienced",
+   "fieldtype": "Check",
+   "label": "Is Experienced"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_user_created",
+   "fieldtype": "Check",
+   "label": "Is User Created",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.status==\"Active\"",
+   "fieldname": "suntek_mobile_number",
+   "fieldtype": "Data",
+   "label": "Suntek Mobile Number",
+   "mandatory_depends_on": "eval:doc.status==\"Active\""
+  },
+  {
+   "depends_on": "eval:doc.status==\"Active\"",
+   "fieldname": "suntek_email",
+   "fieldtype": "Data",
+   "label": "Suntek Email",
+   "mandatory_depends_on": "eval:doc.status==\"Active\""
+  },
+  {
+   "fieldname": "linked_user",
+   "fieldtype": "Link",
+   "label": "Linked User",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_zuam",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "contact",
+   "fieldtype": "Link",
+   "label": "Contact",
+   "options": "Contact",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "dealer_address.address_line1",
+   "fieldname": "address",
+   "fieldtype": "Small Text",
+   "label": "Address Line 1",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "dealer_address.address_line2",
+   "fieldname": "address_line_2",
+   "fieldtype": "Small Text",
+   "label": "Address Line 2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_gcmk",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "district",
+   "fieldtype": "Link",
+   "label": "District",
+   "options": "District",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "district.country",
+   "fieldname": "country",
+   "fieldtype": "Data",
+   "label": "Country",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "district.state",
+   "fieldname": "state",
+   "fieldtype": "Data",
+   "label": "State",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "district.state_code",
+   "fieldname": "state_code",
+   "fieldtype": "Data",
+   "label": "State Code",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "district.city",
+   "fieldname": "city",
+   "fieldtype": "Data",
+   "label": "City",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "district.district_snake_case",
+   "fieldname": "district_snake_case",
+   "fieldtype": "Data",
+   "label": "District Snake Case",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.is_experienced == 1",
+   "fieldname": "past_experience_tab",
+   "fieldtype": "Tab Break",
+   "label": "Past Experience"
+  },
+  {
+   "fieldname": "past_experience_section",
+   "fieldtype": "Section Break",
+   "label": "Past Experience"
+  },
+  {
+   "fieldname": "past_experience",
+   "fieldtype": "Table",
+   "label": "Past Experience",
+   "mandatory_depends_on": "eval:doc.is_experienced == 1",
+   "options": "Past Experience"
+  },
+  {
+   "fieldname": "attachments_tab",
+   "fieldtype": "Tab Break",
+   "label": "Attachments"
+  },
+  {
+   "fieldname": "personal_kyc_section",
+   "fieldtype": "Section Break",
+   "label": "Personal KYC"
+  },
+  {
+   "fieldname": "id_proof",
+   "fieldtype": "Attach",
+   "label": "Aadhar Card",
+   "reqd": 1
+  },
+  {
+   "fieldname": "pan_card",
+   "fieldtype": "Attach",
+   "label": "PAN Card",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_sjnq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "photograph",
+   "fieldtype": "Attach Image",
+   "label": "Photograph",
+   "reqd": 1
+  },
+  {
+   "fieldname": "electricity_bill",
+   "fieldtype": "Attach",
+   "label": "Electricity Bill",
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_break_zker",
+   "fieldtype": "Section Break",
+   "label": "Additional Attachments"
+  },
+  {
+   "fieldname": "other_documents",
+   "fieldtype": "Table",
+   "label": "Other Documents",
+   "options": "Additional Attachments"
+  },
+  {
+   "fieldname": "pin_codes_tab",
+   "fieldtype": "Tab Break",
+   "label": "PIN Codes"
+  },
+  {
+   "fieldname": "associated_pin_codes",
+   "fieldtype": "Table",
+   "label": "Associated PIN Codes",
+   "options": "District PIN Code Table"
+  },
+  {
+   "fieldname": "connections_tab",
+   "fieldtype": "Tab Break",
+   "label": "Connections",
+   "show_dashboard": 1
+  },
+  {
+   "fieldname": "dashboard_tab",
+   "fieldtype": "Tab Break",
+   "label": "Dashboard"
+  },
+  {
+   "fieldname": "dashboard_html",
+   "fieldtype": "HTML",
+   "label": "Dashboard HTML"
+  },
+  {
+   "fieldname": "channel_partner_address",
+   "fieldtype": "Link",
+   "label": "Channel Partner Address",
+   "options": "Address",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "district.district",
+   "fieldname": "district_name",
+   "fieldtype": "Data",
+   "label": "District Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "linked_customer",
+   "fieldtype": "Link",
+   "label": "Linked Customer",
+   "options": "Customer",
+   "read_only": 1
+  },
+  {
+   "fieldname": "default_sales_warehouse",
+   "fieldtype": "Link",
+   "label": "Default Sales Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "default_subsidy_warehouse",
+   "fieldtype": "Link",
+   "label": "Default Subsidy Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "selling_tab",
+   "fieldtype": "Tab Break",
+   "label": "Selling"
+  },
+  {
+   "fieldname": "warehouses_section",
+   "fieldtype": "Section Break",
+   "label": "Warehouses"
+  },
+  {
+   "fieldname": "column_break_gixt",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "price_list_section",
+   "fieldtype": "Section Break",
+   "label": "Price List"
+  },
+  {
+   "fieldname": "default_selling_list",
+   "fieldtype": "Link",
+   "label": "Default Selling List",
+   "options": "Price List"
+  },
+  {
+   "fieldname": "column_break_vism",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "default_buying_list",
+   "fieldtype": "Link",
+   "label": "Default Buying List",
+   "options": "Price List"
+  },
+  {
+   "fetch_from": "channel_partner_firm.customer",
+   "fieldname": "channel_partner_customer",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Channel Partner Customer",
+   "options": "Customer"
+  },
+  {
+   "fetch_from": "district.territory",
+   "fieldname": "territory",
+   "fieldtype": "Data",
+   "label": "Territory"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [
+  {
+   "link_doctype": "Lead",
+   "link_fieldname": "custom_channel_partner"
+  },
+  {
+   "link_doctype": "Opportunity",
+   "link_fieldname": "custom_channel_partner"
+  },
+  {
+   "link_doctype": "Quotation",
+   "link_fieldname": "custom_channel_partner"
+  },
+  {
+   "link_doctype": "Sales Order",
+   "link_fieldname": "custom_channel_partner"
+  },
+  {
+   "link_doctype": "Site Survey",
+   "link_fieldname": "channel_partner"
+  },
+  {
+   "link_doctype": "Sales Invoice",
+   "link_fieldname": "custom_channel_partner"
+  },
+  {
+   "link_doctype": "Project",
+   "link_fieldname": "custom_channel_partner"
+  },
+  {
+   "link_doctype": "Designing",
+   "link_fieldname": "channel_partner"
+  },
+  {
+   "link_doctype": "BOM",
+   "link_fieldname": "custom_channel_partner"
+  },
+  {
+   "link_doctype": "Discom",
+   "link_fieldname": "channel_partner"
+  },
+  {
+   "link_doctype": "Subsidy",
+   "link_fieldname": "channel_partner"
+  },
+  {
+   "link_doctype": "Channel Partner Purchase Order",
+   "link_fieldname": "channel_partner"
+  }
+ ],
+ "modified": "2025-03-31 13:21:58.863720",
+ "modified_by": "Administrator",
+ "module": "Channel Partner",
+ "name": "Channel Partner",
+ "naming_rule": "By script",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Channel Partner Manager",
+   "select": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Channel Partner",
+   "select": 1
+  }
+ ],
+ "search_fields": "channel_partner_name",
+ "show_name_in_global_search": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [
+  {
+   "color": "Green",
+   "title": "Enabled"
+  },
+  {
+   "color": "Red",
+   "title": "Disabled"
+  }
+ ],
+ "title_field": "channel_partner_name"
 }

--- a/suntek_app/channel_partner/doctype/channel_partner/channel_partner.py
+++ b/suntek_app/channel_partner/doctype/channel_partner/channel_partner.py
@@ -179,7 +179,7 @@ class ChannelPartner(Document):
             linked_user = None
             default_sales_warehouse = None
             default_subsidy_warehouse = None
-            # linked_customer = None
+
             warehouses_created = False
             permissions_created = []
 
@@ -297,9 +297,6 @@ class ChannelPartner(Document):
                     if firm_perm:
                         permissions_created.append("Channel Partner Firm")
 
-            # customer_name = self._create_customer(linked_user)
-            # linked_customer = customer_name
-
             self.linked_user = linked_user
             self.is_user_created = 1
 
@@ -307,9 +304,6 @@ class ChannelPartner(Document):
                 self.default_sales_warehouse = default_sales_warehouse
                 self.default_subsidy_warehouse = default_subsidy_warehouse
                 self.warehouse = default_sales_warehouse
-
-            # if linked_customer:
-            #     self.linked_customer = linked_customer
 
             self.flags.ignore_mandatory = True
             self.save()
@@ -319,8 +313,7 @@ class ChannelPartner(Document):
             success_message = f"Successfully created user account for {self.channel_partner_name}"
             if warehouses_created:
                 success_message += "\nCreated Sales and Subsidy warehouses"
-            # if customer_name:
-            #     success_message += f"\nCreated Customer: {customer_name}"
+
             success_message += f"\nCreated permissions: {', '.join(permissions_created)}"
 
             frappe.msgprint(success_message)
@@ -511,8 +504,6 @@ class ChannelPartner(Document):
 
                 new_address.flags.ignore_permissions = True
                 new_address.insert()
-
-            # self.db_set("linked_customer", customer.name)
 
             return customer.name
 

--- a/suntek_app/channel_partner/doctype/channel_partner_firm/channel_partner_firm.js
+++ b/suntek_app/channel_partner/doctype/channel_partner_firm/channel_partner_firm.js
@@ -16,7 +16,7 @@ frappe.ui.form.on("Channel Partner Firm", {
             firm_name: ["like", "%" + frm.doc.firm_name + "%"],
           });
         },
-        __("View"),
+        __("View")
       );
     }
   },
@@ -31,8 +31,8 @@ frappe.ui.form.on("Channel Partner Firm", {
       if (!valid_format) {
         frappe.msgprint(
           __(
-            "Firm Code should be 2-10 characters containing only uppercase letters and numbers.",
-          ),
+            "Firm Code should be 2-10 characters containing only uppercase letters and numbers."
+          )
         );
         frappe.validated = false;
       }

--- a/suntek_app/channel_partner/doctype/channel_partner_firm/channel_partner_firm.js
+++ b/suntek_app/channel_partner/doctype/channel_partner_firm/channel_partner_firm.js
@@ -1,13 +1,21 @@
 frappe.ui.form.on("Channel Partner Firm", {
   refresh: function (frm) {
     frm.trigger("render_address_and_contact");
-
     if (!frm.is_new()) {
       frm.add_custom_button(__("Create Channel Partner"), function () {
         frappe.new_doc("Channel Partner", {
           channel_partner_firm: frm.doc.name,
         });
       });
+
+      if (frm.doc.status === "Active" && !frm.doc.linked_sales_partner) {
+        frm.add_custom_button("Create Sales Partner", function () {
+          frm.call({
+            doc: frm.doc,
+            method: "create_sales_partner",
+          });
+        });
+      }
 
       frm.add_custom_button(
         __("Show Similar Firms"),

--- a/suntek_app/channel_partner/doctype/channel_partner_firm/channel_partner_firm.json
+++ b/suntek_app/channel_partner/doctype/channel_partner_firm/channel_partner_firm.json
@@ -1,291 +1,298 @@
 {
- "actions": [],
- "allow_rename": 1,
- "creation": "2025-03-12 16:47:40.153669",
- "doctype": "DocType",
- "engine": "InnoDB",
- "field_order": [
-  "firm_name",
-  "status",
-  "section_break_address_and_contact",
-  "address_html",
-  "column_break_address",
-  "contact_html",
-  "address_and_contact_section",
-  "address",
-  "address_display",
-  "column_break_contact",
-  "customer",
-  "customer_name",
-  "contact_person",
-  "contact_display",
-  "contact_email",
-  "contact_mobile",
-  "section_break_channel_partners",
-  "channel_partners",
-  "kyc_tab",
-  "section_break_business_details",
-  "gst_number",
-  "pan_number",
-  "column_break_business",
-  "establishment_date",
-  "section_break_nyhu",
-  "agreement",
-  "noc_for_stock",
-  "gst_registration",
-  "column_break_jzuq",
-  "address_proof",
-  "pan_company",
-  "business_registration",
-  "section_break_gefe",
-  "selling_price_list",
-  "payment_terms_template"
- ],
- "fields": [
-  {
-   "fieldname": "firm_name",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Firm Name",
-   "reqd": 1
-  },
-  {
-   "default": "Pending Approval",
-   "fieldname": "status",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Status",
-   "options": "Active\nInactive\nPending Approval"
-  },
-  {
-   "fieldname": "section_break_address_and_contact",
-   "fieldtype": "Section Break",
-   "hidden": 1,
-   "label": "Address and Contact"
-  },
-  {
-   "fieldname": "address_html",
-   "fieldtype": "HTML",
-   "label": "Address HTML"
-  },
-  {
-   "fieldname": "column_break_address",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "contact_html",
-   "fieldtype": "HTML",
-   "label": "Contact HTML"
-  },
-  {
-   "depends_on": "eval:!doc.__islocal",
-   "fieldname": "address_and_contact_section",
-   "fieldtype": "Section Break",
-   "label": "Address and Contact Details"
-  },
-  {
-   "fieldname": "address",
-   "fieldtype": "Link",
-   "label": "Address",
-   "mandatory_depends_on": "eval:doc.status == \"Active\"",
-   "options": "Address"
-  },
-  {
-   "fieldname": "address_display",
-   "fieldtype": "Small Text",
-   "label": "Address Display",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_contact",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "contact_person",
-   "fieldtype": "Link",
-   "label": "Contact Person",
-   "mandatory_depends_on": "eval:doc.status == \"Active\"",
-   "options": "Contact"
-  },
-  {
-   "depends_on": "contact_person",
-   "fetch_from": "contact_person.email_id",
-   "fieldname": "contact_email",
-   "fieldtype": "Data",
-   "label": "Contact Email",
-   "read_only": 1
-  },
-  {
-   "depends_on": "contact_person",
-   "fetch_from": "contact_person.mobile_no",
-   "fieldname": "contact_mobile",
-   "fieldtype": "Data",
-   "label": "Contact Mobile",
-   "read_only": 1
-  },
-  {
-   "fetch_from": "contact_person.full_name",
-   "fieldname": "contact_display",
-   "fieldtype": "Data",
-   "label": "Contact Display",
-   "read_only": 1
-  },
-  {
-   "fieldname": "section_break_business_details",
-   "fieldtype": "Section Break",
-   "label": "Business Details"
-  },
-  {
-   "fieldname": "gst_number",
-   "fieldtype": "Data",
-   "in_standard_filter": 1,
-   "label": "GST Number"
-  },
-  {
-   "fieldname": "pan_number",
-   "fieldtype": "Data",
-   "label": "PAN Number"
-  },
-  {
-   "fieldname": "column_break_business",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "establishment_date",
-   "fieldtype": "Date",
-   "label": "Establishment Date"
-  },
-  {
-   "fieldname": "business_registration",
-   "fieldtype": "Attach",
-   "label": "Business Registration"
-  },
-  {
-   "fieldname": "section_break_channel_partners",
-   "fieldtype": "Section Break",
-   "label": "Channel Partners"
-  },
-  {
-   "fieldname": "channel_partners",
-   "fieldtype": "Table",
-   "label": "Channel Partners",
-   "options": "Channel Partner Link"
-  },
-  {
-   "fieldname": "kyc_tab",
-   "fieldtype": "Tab Break",
-   "label": "KYC"
-  },
-  {
-   "fieldname": "agreement",
-   "fieldtype": "Attach",
-   "label": "Agreement"
-  },
-  {
-   "fieldname": "noc_for_stock",
-   "fieldtype": "Attach",
-   "label": "NOC for Stock"
-  },
-  {
-   "fieldname": "column_break_jzuq",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "address_proof",
-   "fieldtype": "Attach",
-   "label": "Address Proof"
-  },
-  {
-   "fieldname": "pan_company",
-   "fieldtype": "Attach",
-   "label": "PAN (Company)"
-  },
-  {
-   "fieldname": "gst_registration",
-   "fieldtype": "Attach",
-   "label": "GST Registration"
-  },
-  {
-   "fieldname": "customer",
-   "fieldtype": "Link",
-   "label": "Customer",
-   "mandatory_depends_on": "eval:doc.status == \"Active\"",
-   "options": "Customer"
-  },
-  {
-   "fetch_from": "customer.customer_name",
-   "fieldname": "customer_name",
-   "fieldtype": "Data",
-   "label": "Customer Name",
-   "read_only": 1
-  },
-  {
-   "fieldname": "section_break_gefe",
-   "fieldtype": "Section Break"
-  },
-  {
-   "description": "The list of prices which we will use to sell items to this Firm",
-   "fieldname": "selling_price_list",
-   "fieldtype": "Link",
-   "label": "Selling Price List",
-   "options": "Price List"
-  },
-  {
-   "fieldname": "section_break_nyhu",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "payment_terms_template",
-   "fieldtype": "Link",
-   "label": "Payment Terms Template",
-   "options": "Payment Terms Template"
-  }
- ],
- "index_web_pages_for_search": 1,
- "links": [
-  {
-   "group": "Channel Partners",
-   "link_doctype": "Channel Partner",
-   "link_fieldname": "channel_partner_firm"
-  },
-  {
-   "group": "Address & Contacts",
-   "link_doctype": "Address",
-   "link_fieldname": "link_doctype",
-   "parent_doctype": "Dynamic Link"
-  },
-  {
-   "group": "Address & Contacts",
-   "link_doctype": "Contact",
-   "link_fieldname": "link_doctype",
-   "parent_doctype": "Dynamic Link"
-  }
- ],
- "modified": "2025-03-28 16:42:24.297178",
- "modified_by": "Administrator",
- "module": "Channel Partner",
- "name": "Channel Partner Firm",
- "naming_rule": "Expression",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
- "search_fields": "firm_name, gst_number, contact_person, contact_email, contact_mobile",
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": [],
- "title_field": "firm_name",
- "track_changes": 1
+    "actions": [],
+    "allow_rename": 1,
+    "creation": "2025-03-12 16:47:40.153669",
+    "doctype": "DocType",
+    "engine": "InnoDB",
+    "field_order": [
+        "firm_name",
+        "status",
+        "section_break_address_and_contact",
+        "address_html",
+        "column_break_address",
+        "contact_html",
+        "address_and_contact_section",
+        "address",
+        "address_display",
+        "column_break_contact",
+        "customer",
+        "customer_name",
+        "contact_person",
+        "contact_display",
+        "contact_email",
+        "contact_mobile",
+        "section_break_channel_partners",
+        "channel_partners",
+        "kyc_tab",
+        "section_break_business_details",
+        "gst_number",
+        "pan_number",
+        "column_break_business",
+        "establishment_date",
+        "section_break_nyhu",
+        "agreement",
+        "noc_for_stock",
+        "gst_registration",
+        "column_break_jzuq",
+        "address_proof",
+        "pan_company",
+        "business_registration",
+        "section_break_gefe",
+        "selling_price_list",
+        "taxes_and_charges_template",
+        "payment_terms_template"
+    ],
+    "fields": [
+        {
+            "fieldname": "firm_name",
+            "fieldtype": "Data",
+            "in_list_view": 1,
+            "in_standard_filter": 1,
+            "label": "Firm Name",
+            "reqd": 1
+        },
+        {
+            "default": "Pending Approval",
+            "fieldname": "status",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "label": "Status",
+            "options": "Active\nInactive\nPending Approval"
+        },
+        {
+            "fieldname": "section_break_address_and_contact",
+            "fieldtype": "Section Break",
+            "hidden": 1,
+            "label": "Address and Contact"
+        },
+        {
+            "fieldname": "address_html",
+            "fieldtype": "HTML",
+            "label": "Address HTML"
+        },
+        {
+            "fieldname": "column_break_address",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "contact_html",
+            "fieldtype": "HTML",
+            "label": "Contact HTML"
+        },
+        {
+            "depends_on": "eval:!doc.__islocal",
+            "fieldname": "address_and_contact_section",
+            "fieldtype": "Section Break",
+            "label": "Address and Contact Details"
+        },
+        {
+            "fieldname": "address",
+            "fieldtype": "Link",
+            "label": "Address",
+            "mandatory_depends_on": "eval:doc.status == \"Active\"",
+            "options": "Address"
+        },
+        {
+            "fieldname": "address_display",
+            "fieldtype": "Small Text",
+            "label": "Address Display",
+            "read_only": 1
+        },
+        {
+            "fieldname": "column_break_contact",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "contact_person",
+            "fieldtype": "Link",
+            "label": "Contact Person",
+            "mandatory_depends_on": "eval:doc.status == \"Active\"",
+            "options": "Contact"
+        },
+        {
+            "depends_on": "contact_person",
+            "fetch_from": "contact_person.email_id",
+            "fieldname": "contact_email",
+            "fieldtype": "Data",
+            "label": "Contact Email",
+            "read_only": 1
+        },
+        {
+            "depends_on": "contact_person",
+            "fetch_from": "contact_person.mobile_no",
+            "fieldname": "contact_mobile",
+            "fieldtype": "Data",
+            "label": "Contact Mobile",
+            "read_only": 1
+        },
+        {
+            "fetch_from": "contact_person.full_name",
+            "fieldname": "contact_display",
+            "fieldtype": "Data",
+            "label": "Contact Display",
+            "read_only": 1
+        },
+        {
+            "fieldname": "section_break_business_details",
+            "fieldtype": "Section Break",
+            "label": "Business Details"
+        },
+        {
+            "fieldname": "gst_number",
+            "fieldtype": "Data",
+            "in_standard_filter": 1,
+            "label": "GST Number"
+        },
+        {
+            "fieldname": "pan_number",
+            "fieldtype": "Data",
+            "label": "PAN Number"
+        },
+        {
+            "fieldname": "column_break_business",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "establishment_date",
+            "fieldtype": "Date",
+            "label": "Establishment Date"
+        },
+        {
+            "fieldname": "business_registration",
+            "fieldtype": "Attach",
+            "label": "Business Registration"
+        },
+        {
+            "fieldname": "section_break_channel_partners",
+            "fieldtype": "Section Break",
+            "label": "Channel Partners"
+        },
+        {
+            "fieldname": "channel_partners",
+            "fieldtype": "Table",
+            "label": "Channel Partners",
+            "options": "Channel Partner Link"
+        },
+        {
+            "fieldname": "kyc_tab",
+            "fieldtype": "Tab Break",
+            "label": "KYC"
+        },
+        {
+            "fieldname": "agreement",
+            "fieldtype": "Attach",
+            "label": "Agreement"
+        },
+        {
+            "fieldname": "noc_for_stock",
+            "fieldtype": "Attach",
+            "label": "NOC for Stock"
+        },
+        {
+            "fieldname": "column_break_jzuq",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "address_proof",
+            "fieldtype": "Attach",
+            "label": "Address Proof"
+        },
+        {
+            "fieldname": "pan_company",
+            "fieldtype": "Attach",
+            "label": "PAN (Company)"
+        },
+        {
+            "fieldname": "gst_registration",
+            "fieldtype": "Attach",
+            "label": "GST Registration"
+        },
+        {
+            "fieldname": "customer",
+            "fieldtype": "Link",
+            "label": "Customer",
+            "mandatory_depends_on": "eval:doc.status == \"Active\"",
+            "options": "Customer"
+        },
+        {
+            "fetch_from": "customer.customer_name",
+            "fieldname": "customer_name",
+            "fieldtype": "Data",
+            "label": "Customer Name",
+            "read_only": 1
+        },
+        {
+            "fieldname": "section_break_gefe",
+            "fieldtype": "Section Break"
+        },
+        {
+            "description": "The list of prices which we will use to sell items to this Firm",
+            "fieldname": "selling_price_list",
+            "fieldtype": "Link",
+            "label": "Selling Price List",
+            "options": "Price List"
+        },
+        {
+            "fieldname": "taxes_and_charges_template",
+            "fieldtype": "Link",
+            "label": "Taxes and Charges Template",
+            "options": "Sales Taxes and Charges Template"
+        },
+        {
+            "fieldname": "section_break_nyhu",
+            "fieldtype": "Section Break"
+        },
+        {
+            "fieldname": "payment_terms_template",
+            "fieldtype": "Link",
+            "label": "Payment Terms Template",
+            "options": "Payment Terms Template"
+        }
+    ],
+    "index_web_pages_for_search": 1,
+    "links": [
+        {
+            "group": "Channel Partners",
+            "link_doctype": "Channel Partner",
+            "link_fieldname": "channel_partner_firm"
+        },
+        {
+            "group": "Address & Contacts",
+            "link_doctype": "Address",
+            "link_fieldname": "link_doctype",
+            "parent_doctype": "Dynamic Link"
+        },
+        {
+            "group": "Address & Contacts",
+            "link_doctype": "Contact",
+            "link_fieldname": "link_doctype",
+            "parent_doctype": "Dynamic Link"
+        }
+    ],
+    "modified": "2025-03-28 16:42:24.297178",
+    "modified_by": "Administrator",
+    "module": "Channel Partner",
+    "name": "Channel Partner Firm",
+    "naming_rule": "Expression",
+    "owner": "Administrator",
+    "permissions": [
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "System Manager",
+            "share": 1,
+            "write": 1
+        }
+    ],
+    "search_fields": "firm_name, gst_number, contact_person, contact_email, contact_mobile",
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "states": [],
+    "title_field": "firm_name",
+    "track_changes": 1
 }

--- a/suntek_app/channel_partner/doctype/channel_partner_firm/channel_partner_firm.json
+++ b/suntek_app/channel_partner/doctype/channel_partner_firm/channel_partner_firm.json
@@ -1,298 +1,331 @@
 {
-    "actions": [],
-    "allow_rename": 1,
-    "creation": "2025-03-12 16:47:40.153669",
-    "doctype": "DocType",
-    "engine": "InnoDB",
-    "field_order": [
-        "firm_name",
-        "status",
-        "section_break_address_and_contact",
-        "address_html",
-        "column_break_address",
-        "contact_html",
-        "address_and_contact_section",
-        "address",
-        "address_display",
-        "column_break_contact",
-        "customer",
-        "customer_name",
-        "contact_person",
-        "contact_display",
-        "contact_email",
-        "contact_mobile",
-        "section_break_channel_partners",
-        "channel_partners",
-        "kyc_tab",
-        "section_break_business_details",
-        "gst_number",
-        "pan_number",
-        "column_break_business",
-        "establishment_date",
-        "section_break_nyhu",
-        "agreement",
-        "noc_for_stock",
-        "gst_registration",
-        "column_break_jzuq",
-        "address_proof",
-        "pan_company",
-        "business_registration",
-        "section_break_gefe",
-        "selling_price_list",
-        "taxes_and_charges_template",
-        "payment_terms_template"
-    ],
-    "fields": [
-        {
-            "fieldname": "firm_name",
-            "fieldtype": "Data",
-            "in_list_view": 1,
-            "in_standard_filter": 1,
-            "label": "Firm Name",
-            "reqd": 1
-        },
-        {
-            "default": "Pending Approval",
-            "fieldname": "status",
-            "fieldtype": "Select",
-            "in_list_view": 1,
-            "label": "Status",
-            "options": "Active\nInactive\nPending Approval"
-        },
-        {
-            "fieldname": "section_break_address_and_contact",
-            "fieldtype": "Section Break",
-            "hidden": 1,
-            "label": "Address and Contact"
-        },
-        {
-            "fieldname": "address_html",
-            "fieldtype": "HTML",
-            "label": "Address HTML"
-        },
-        {
-            "fieldname": "column_break_address",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "contact_html",
-            "fieldtype": "HTML",
-            "label": "Contact HTML"
-        },
-        {
-            "depends_on": "eval:!doc.__islocal",
-            "fieldname": "address_and_contact_section",
-            "fieldtype": "Section Break",
-            "label": "Address and Contact Details"
-        },
-        {
-            "fieldname": "address",
-            "fieldtype": "Link",
-            "label": "Address",
-            "mandatory_depends_on": "eval:doc.status == \"Active\"",
-            "options": "Address"
-        },
-        {
-            "fieldname": "address_display",
-            "fieldtype": "Small Text",
-            "label": "Address Display",
-            "read_only": 1
-        },
-        {
-            "fieldname": "column_break_contact",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "contact_person",
-            "fieldtype": "Link",
-            "label": "Contact Person",
-            "mandatory_depends_on": "eval:doc.status == \"Active\"",
-            "options": "Contact"
-        },
-        {
-            "depends_on": "contact_person",
-            "fetch_from": "contact_person.email_id",
-            "fieldname": "contact_email",
-            "fieldtype": "Data",
-            "label": "Contact Email",
-            "read_only": 1
-        },
-        {
-            "depends_on": "contact_person",
-            "fetch_from": "contact_person.mobile_no",
-            "fieldname": "contact_mobile",
-            "fieldtype": "Data",
-            "label": "Contact Mobile",
-            "read_only": 1
-        },
-        {
-            "fetch_from": "contact_person.full_name",
-            "fieldname": "contact_display",
-            "fieldtype": "Data",
-            "label": "Contact Display",
-            "read_only": 1
-        },
-        {
-            "fieldname": "section_break_business_details",
-            "fieldtype": "Section Break",
-            "label": "Business Details"
-        },
-        {
-            "fieldname": "gst_number",
-            "fieldtype": "Data",
-            "in_standard_filter": 1,
-            "label": "GST Number"
-        },
-        {
-            "fieldname": "pan_number",
-            "fieldtype": "Data",
-            "label": "PAN Number"
-        },
-        {
-            "fieldname": "column_break_business",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "establishment_date",
-            "fieldtype": "Date",
-            "label": "Establishment Date"
-        },
-        {
-            "fieldname": "business_registration",
-            "fieldtype": "Attach",
-            "label": "Business Registration"
-        },
-        {
-            "fieldname": "section_break_channel_partners",
-            "fieldtype": "Section Break",
-            "label": "Channel Partners"
-        },
-        {
-            "fieldname": "channel_partners",
-            "fieldtype": "Table",
-            "label": "Channel Partners",
-            "options": "Channel Partner Link"
-        },
-        {
-            "fieldname": "kyc_tab",
-            "fieldtype": "Tab Break",
-            "label": "KYC"
-        },
-        {
-            "fieldname": "agreement",
-            "fieldtype": "Attach",
-            "label": "Agreement"
-        },
-        {
-            "fieldname": "noc_for_stock",
-            "fieldtype": "Attach",
-            "label": "NOC for Stock"
-        },
-        {
-            "fieldname": "column_break_jzuq",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "address_proof",
-            "fieldtype": "Attach",
-            "label": "Address Proof"
-        },
-        {
-            "fieldname": "pan_company",
-            "fieldtype": "Attach",
-            "label": "PAN (Company)"
-        },
-        {
-            "fieldname": "gst_registration",
-            "fieldtype": "Attach",
-            "label": "GST Registration"
-        },
-        {
-            "fieldname": "customer",
-            "fieldtype": "Link",
-            "label": "Customer",
-            "mandatory_depends_on": "eval:doc.status == \"Active\"",
-            "options": "Customer"
-        },
-        {
-            "fetch_from": "customer.customer_name",
-            "fieldname": "customer_name",
-            "fieldtype": "Data",
-            "label": "Customer Name",
-            "read_only": 1
-        },
-        {
-            "fieldname": "section_break_gefe",
-            "fieldtype": "Section Break"
-        },
-        {
-            "description": "The list of prices which we will use to sell items to this Firm",
-            "fieldname": "selling_price_list",
-            "fieldtype": "Link",
-            "label": "Selling Price List",
-            "options": "Price List"
-        },
-        {
-            "fieldname": "taxes_and_charges_template",
-            "fieldtype": "Link",
-            "label": "Taxes and Charges Template",
-            "options": "Sales Taxes and Charges Template"
-        },
-        {
-            "fieldname": "section_break_nyhu",
-            "fieldtype": "Section Break"
-        },
-        {
-            "fieldname": "payment_terms_template",
-            "fieldtype": "Link",
-            "label": "Payment Terms Template",
-            "options": "Payment Terms Template"
-        }
-    ],
-    "index_web_pages_for_search": 1,
-    "links": [
-        {
-            "group": "Channel Partners",
-            "link_doctype": "Channel Partner",
-            "link_fieldname": "channel_partner_firm"
-        },
-        {
-            "group": "Address & Contacts",
-            "link_doctype": "Address",
-            "link_fieldname": "link_doctype",
-            "parent_doctype": "Dynamic Link"
-        },
-        {
-            "group": "Address & Contacts",
-            "link_doctype": "Contact",
-            "link_fieldname": "link_doctype",
-            "parent_doctype": "Dynamic Link"
-        }
-    ],
-    "modified": "2025-03-28 16:42:24.297178",
-    "modified_by": "Administrator",
-    "module": "Channel Partner",
-    "name": "Channel Partner Firm",
-    "naming_rule": "Expression",
-    "owner": "Administrator",
-    "permissions": [
-        {
-            "create": 1,
-            "delete": 1,
-            "email": 1,
-            "export": 1,
-            "print": 1,
-            "read": 1,
-            "report": 1,
-            "role": "System Manager",
-            "share": 1,
-            "write": 1
-        }
-    ],
-    "search_fields": "firm_name, gst_number, contact_person, contact_email, contact_mobile",
-    "sort_field": "modified",
-    "sort_order": "DESC",
-    "states": [],
-    "title_field": "firm_name",
-    "track_changes": 1
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-03-12 16:47:40.153669",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "firm_name",
+  "status",
+  "section_break_address_and_contact",
+  "address_html",
+  "column_break_address",
+  "contact_html",
+  "address_and_contact_section",
+  "territory",
+  "address",
+  "address_display",
+  "column_break_contact",
+  "customer",
+  "customer_name",
+  "contact_person",
+  "contact_display",
+  "contact_email",
+  "contact_mobile",
+  "section_break_channel_partners",
+  "channel_partners",
+  "kyc_tab",
+  "section_break_business_details",
+  "gst_number",
+  "pan_number",
+  "column_break_business",
+  "establishment_date",
+  "section_break_nyhu",
+  "agreement",
+  "noc_for_stock",
+  "gst_registration",
+  "column_break_jzuq",
+  "address_proof",
+  "pan_company",
+  "business_registration",
+  "sales_tab",
+  "section_break_gefe",
+  "selling_price_list",
+  "taxes_and_charges_template",
+  "payment_terms_template",
+  "column_break_jxrs",
+  "commission_rate",
+  "linked_sales_partner"
+ ],
+ "fields": [
+  {
+   "fieldname": "firm_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Firm Name",
+   "reqd": 1
+  },
+  {
+   "default": "Pending Approval",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "Active\nInactive\nPending Approval"
+  },
+  {
+   "fieldname": "section_break_address_and_contact",
+   "fieldtype": "Section Break",
+   "hidden": 1,
+   "label": "Address and Contact"
+  },
+  {
+   "fieldname": "address_html",
+   "fieldtype": "HTML",
+   "label": "Address HTML"
+  },
+  {
+   "fieldname": "column_break_address",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "contact_html",
+   "fieldtype": "HTML",
+   "label": "Contact HTML"
+  },
+  {
+   "depends_on": "eval:!doc.__islocal",
+   "fieldname": "address_and_contact_section",
+   "fieldtype": "Section Break",
+   "label": "Address and Contact Details"
+  },
+  {
+   "fieldname": "address",
+   "fieldtype": "Link",
+   "label": "Address",
+   "mandatory_depends_on": "eval:doc.status == \"Active\"",
+   "options": "Address"
+  },
+  {
+   "fieldname": "address_display",
+   "fieldtype": "Small Text",
+   "label": "Address Display",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_contact",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "contact_person",
+   "fieldtype": "Link",
+   "label": "Contact Person",
+   "mandatory_depends_on": "eval:doc.status == \"Active\"",
+   "options": "Contact"
+  },
+  {
+   "depends_on": "contact_person",
+   "fetch_from": "contact_person.email_id",
+   "fieldname": "contact_email",
+   "fieldtype": "Data",
+   "label": "Contact Email",
+   "read_only": 1
+  },
+  {
+   "depends_on": "contact_person",
+   "fetch_from": "contact_person.mobile_no",
+   "fieldname": "contact_mobile",
+   "fieldtype": "Data",
+   "label": "Contact Mobile",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "contact_person.full_name",
+   "fieldname": "contact_display",
+   "fieldtype": "Data",
+   "label": "Contact Display",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_business_details",
+   "fieldtype": "Section Break",
+   "label": "Business Details"
+  },
+  {
+   "fieldname": "gst_number",
+   "fieldtype": "Data",
+   "in_standard_filter": 1,
+   "label": "GST Number"
+  },
+  {
+   "fieldname": "pan_number",
+   "fieldtype": "Data",
+   "label": "PAN Number"
+  },
+  {
+   "fieldname": "column_break_business",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "establishment_date",
+   "fieldtype": "Date",
+   "label": "Establishment Date"
+  },
+  {
+   "fieldname": "business_registration",
+   "fieldtype": "Attach",
+   "label": "Business Registration"
+  },
+  {
+   "fieldname": "section_break_channel_partners",
+   "fieldtype": "Section Break",
+   "label": "Channel Partners"
+  },
+  {
+   "fieldname": "channel_partners",
+   "fieldtype": "Table",
+   "label": "Channel Partners",
+   "options": "Channel Partner Link"
+  },
+  {
+   "fieldname": "kyc_tab",
+   "fieldtype": "Tab Break",
+   "label": "KYC"
+  },
+  {
+   "fieldname": "agreement",
+   "fieldtype": "Attach",
+   "label": "Agreement"
+  },
+  {
+   "fieldname": "noc_for_stock",
+   "fieldtype": "Attach",
+   "label": "NOC for Stock"
+  },
+  {
+   "fieldname": "column_break_jzuq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "address_proof",
+   "fieldtype": "Attach",
+   "label": "Address Proof"
+  },
+  {
+   "fieldname": "pan_company",
+   "fieldtype": "Attach",
+   "label": "PAN (Company)"
+  },
+  {
+   "fieldname": "gst_registration",
+   "fieldtype": "Attach",
+   "label": "GST Registration"
+  },
+  {
+   "fieldname": "customer",
+   "fieldtype": "Link",
+   "label": "Customer",
+   "mandatory_depends_on": "eval:doc.status == \"Active\"",
+   "options": "Customer"
+  },
+  {
+   "fetch_from": "customer.customer_name",
+   "fieldname": "customer_name",
+   "fieldtype": "Data",
+   "label": "Customer Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_gefe",
+   "fieldtype": "Section Break"
+  },
+  {
+   "description": "The list of prices which we will use to sell items to this Firm",
+   "fieldname": "selling_price_list",
+   "fieldtype": "Link",
+   "label": "Selling Price List",
+   "options": "Price List"
+  },
+  {
+   "fieldname": "taxes_and_charges_template",
+   "fieldtype": "Link",
+   "label": "Taxes and Charges Template",
+   "options": "Sales Taxes and Charges Template"
+  },
+  {
+   "fieldname": "section_break_nyhu",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "payment_terms_template",
+   "fieldtype": "Link",
+   "label": "Payment Terms Template",
+   "options": "Payment Terms Template"
+  },
+  {
+   "fieldname": "territory",
+   "fieldtype": "Link",
+   "label": "Territory",
+   "mandatory_depends_on": "eval:doc.status == \"Active\"",
+   "options": "Territory"
+  },
+  {
+   "fieldname": "sales_tab",
+   "fieldtype": "Tab Break",
+   "label": "Sales"
+  },
+  {
+   "fieldname": "column_break_jxrs",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "commission_rate",
+   "fieldtype": "Float",
+   "label": "Commission Rate",
+   "mandatory_depends_on": "eval:doc.status == \"Active\""
+  },
+  {
+   "fieldname": "linked_sales_partner",
+   "fieldtype": "Link",
+   "label": "Linked Sales Partner",
+   "options": "Sales Partner"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [
+  {
+   "group": "Channel Partners",
+   "link_doctype": "Channel Partner",
+   "link_fieldname": "channel_partner_firm"
+  },
+  {
+   "group": "Address & Contacts",
+   "link_doctype": "Address",
+   "link_fieldname": "link_doctype",
+   "parent_doctype": "Dynamic Link"
+  },
+  {
+   "group": "Address & Contacts",
+   "link_doctype": "Contact",
+   "link_fieldname": "link_doctype",
+   "parent_doctype": "Dynamic Link"
+  }
+ ],
+ "modified": "2025-03-31 13:08:25.051694",
+ "modified_by": "Administrator",
+ "module": "Channel Partner",
+ "name": "Channel Partner Firm",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "search_fields": "firm_name, gst_number, contact_person, contact_email, contact_mobile",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "firm_name",
+ "track_changes": 1
 }

--- a/suntek_app/channel_partner/doctype/channel_partner_purchase_order/channel_partner_purchase_order.js
+++ b/suntek_app/channel_partner/doctype/channel_partner_purchase_order/channel_partner_purchase_order.js
@@ -34,7 +34,7 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
         function () {
           frappe.confirm(
             __(
-              "Create a Sales Order with the Channel Partner as the customer?",
+              "Create a Sales Order with the Channel Partner as the customer?"
             ),
             function () {
               frm.call({
@@ -51,10 +51,10 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
                   }
                 },
               });
-            },
+            }
           );
         },
-        __("Actions"),
+        __("Actions")
       );
     }
 
@@ -64,7 +64,7 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
         function () {
           frappe.set_route("Form", "Sales Order", frm.doc.sales_order);
         },
-        __("Actions"),
+        __("Actions")
       );
     }
 
@@ -72,9 +72,9 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
       frm.set_intro(
         __(
           "Note: Channel Partner Purchase Orders are not typically needed for Subsidy cases. " +
-            "For subsidy cases, regular sales process is followed.",
+            "For subsidy cases, regular sales process is followed."
         ),
-        "red",
+        "red"
       );
     }
 
@@ -86,8 +86,8 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
       frm.set_intro(
         __(
           "This purchase order is awaiting review. Once approved, a Sales Order will be created " +
-            "with the Channel Partner as the customer.",
-        ),
+            "with the Channel Partner as the customer."
+        )
       );
     }
 
@@ -95,9 +95,9 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
       frm.set_intro(
         __(
           "A Sales Order has been created from this purchase order. " +
-            "The Channel Partner is set as the customer.",
+            "The Channel Partner is set as the customer."
         ),
-        "green",
+        "green"
       );
     }
 
@@ -147,7 +147,7 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
           if (r && r.default_selling_list) {
             frm.set_value("price_list", r.default_selling_list);
           }
-        },
+        }
       );
 
       if (frm.doc.items && frm.doc.items.length > 0) {
@@ -179,7 +179,7 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
                 item.doctype,
                 item.name,
                 "rate",
-                r.message[item.item_code],
+                r.message[item.item_code]
               );
             }
           });
@@ -207,22 +207,33 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
           if (r && r.custom_channel_partner !== frm.doc.channel_partner) {
             frm.set_value("project", "");
           }
-        },
+        }
       );
     }
-  },
 
-  terms_and_conditions: function (frm) {
-    if (frm.doc.terms_and_conditions) {
+    // Get tax template from firm
+    if (frm.doc.channel_partner) {
       frappe.db.get_value(
-        "Terms and Conditions",
-        frm.doc.terms_and_conditions,
-        "terms",
+        "Channel Partner",
+        frm.doc.channel_partner,
+        "channel_partner_firm",
         function (r) {
-          if (r && r.terms) {
-            frm.set_value("terms_and_conditions_details", r.terms);
+          if (r && r.channel_partner_firm) {
+            frappe.db.get_value(
+              "Channel Partner Firm",
+              r.channel_partner_firm,
+              "taxes_and_charges_template",
+              function (firm_r) {
+                if (firm_r && firm_r.taxes_and_charges_template) {
+                  frm.set_value(
+                    "taxes_and_charges_template",
+                    firm_r.taxes_and_charges_template
+                  );
+                }
+              }
+            );
           }
-        },
+        }
       );
     }
   },
@@ -240,13 +251,13 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
             if (r.custom_type_of_case === "Subsidy") {
               frappe.show_alert({
                 message: __(
-                  "Channel Partner Purchase Orders are typically not needed for Subsidy cases.",
+                  "Channel Partner Purchase Orders are typically not needed for Subsidy cases."
                 ),
                 indicator: "orange",
               });
             }
           }
-        },
+        }
       );
 
       if (frm.doc.project) {
@@ -261,11 +272,11 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
               if (frm.doc.items && frm.doc.items.length > 0) {
                 frappe.confirm(
                   __(
-                    "This will replace the current items and terms with those from the Sales Order. Continue?",
+                    "This will replace the current items and terms with those from the Sales Order. Continue?"
                   ),
                   function () {
                     populate_from_sales_order(frm, r.message);
-                  },
+                  }
                 );
               } else {
                 populate_from_sales_order(frm, r.message);
@@ -290,11 +301,11 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
             if (frm.doc.items && frm.doc.items.length > 0) {
               frappe.confirm(
                 __(
-                  "This will replace the current items and terms with those from the Quotation. Continue?",
+                  "This will replace the current items and terms with those from the Quotation. Continue?"
                 ),
                 function () {
                   populate_from_quotation(frm, r.message);
-                },
+                }
               );
             } else {
               populate_from_quotation(frm, r.message);
@@ -308,7 +319,7 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
     if (frm.doc.type_of_case === "Subsidy") {
       frappe.show_alert({
         message: __(
-          "Channel Partner Purchase Orders are typically not needed for Subsidy cases.",
+          "Channel Partner Purchase Orders are typically not needed for Subsidy cases."
         ),
         indicator: "orange",
       });
@@ -324,7 +335,7 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
         function () {
           var taxes_template = frappe.get_doc(
             "Sales Taxes and Charges Template",
-            frm.doc.taxes_and_charges_template,
+            frm.doc.taxes_and_charges_template
           );
 
           $.each(taxes_template.taxes || [], function (i, tax) {
@@ -336,7 +347,8 @@ frappe.ui.form.on("Channel Partner Purchase Order", {
           });
 
           frm.refresh_field("taxes");
-        },
+          frm.trigger("calculate_total");
+        }
       );
     }
   },
@@ -416,7 +428,7 @@ frappe.ui.form.on("Channel Partner Purchase Order Item", {
                       cdt,
                       cdn,
                       "rate",
-                      response.message[row.item_code],
+                      response.message[row.item_code]
                     );
 
                     setTimeout(function () {
@@ -439,7 +451,7 @@ frappe.ui.form.on("Channel Partner Purchase Order Item", {
               }, 100);
             }
           }
-        },
+        }
       );
     }
   },
@@ -533,68 +545,7 @@ function populate_from_sales_order(frm, data) {
   frappe.show_alert({
     message: __(
       "Items fetched from Sales Order {0}. Please add taxes manually.",
-      [data.sales_order],
-    ),
-    indicator: "green",
-  });
-}
-
-function populate_from_sales_order(frm, data) {
-  if (data.terms_and_conditions) {
-    frm.set_value("terms_and_conditions", data.terms_and_conditions);
-  } else if (data.terms) {
-    frm.set_value("terms_and_conditions_details", data.terms);
-  }
-
-  frm.clear_table("items");
-  let total_amount = 0;
-  let total_qty = 0;
-
-  data.items.forEach(function (item) {
-    var row = frm.add_child("items");
-    row.item_code = item.item_code;
-    row.item_name = item.item_name;
-    row.description = item.description;
-    row.qty = item.qty;
-    row.uom = item.uom;
-    row.rate = item.rate;
-    row.warehouse = item.warehouse;
-
-    if (item.amount) {
-      row.amount = item.amount;
-    } else {
-      row.amount = item.rate * item.qty;
-    }
-
-    total_amount += flt(row.amount);
-    total_qty += flt(item.qty);
-  });
-
-  frm.set_value("total", total_amount);
-  frm.set_value("total_qty", total_qty);
-
-  frm.set_value("grand_total", total_amount);
-
-  if (frm.doc.advance_amount) {
-    frm.set_value("balance_amount", total_amount - flt(frm.doc.advance_amount));
-  } else {
-    frm.set_value("balance_amount", total_amount);
-  }
-
-  frm.refresh_fields([
-    "items",
-    "terms_and_conditions",
-    "terms_and_conditions_details",
-    "total",
-    "total_qty",
-    "grand_total",
-    "balance_amount",
-  ]);
-
-  frappe.show_alert({
-    message: __(
-      "Items fetched from Sales Order {0}. Please add taxes manually.",
-      [data.sales_order],
+      [data.sales_order]
     ),
     indicator: "green",
   });
@@ -644,7 +595,7 @@ function populate_from_quotation(frm, data) {
   if (data.taxes_and_charges_template) {
     frm.set_value(
       "taxes_and_charges_template",
-      data.taxes_and_charges_template,
+      data.taxes_and_charges_template
     );
   }
 
@@ -661,7 +612,7 @@ function populate_from_quotation(frm, data) {
   frappe.show_alert({
     message: __(
       "Items fetched from Quotation {0}. Please add taxes manually if needed.",
-      [data.quotation],
+      [data.quotation]
     ),
     indicator: "green",
   });

--- a/suntek_app/channel_partner/doctype/channel_partner_purchase_order/channel_partner_purchase_order.json
+++ b/suntek_app/channel_partner/doctype/channel_partner_purchase_order/channel_partner_purchase_order.json
@@ -1,308 +1,309 @@
 {
-    "actions": [],
-    "allow_rename": 1,
-    "creation": "2025-03-10 11:39:10.630577",
-    "doctype": "DocType",
-    "engine": "InnoDB",
-    "field_order": [
-        "channel_partner_tab",
-        "channel_partner_details_section",
-        "channel_partner",
-        "channel_partner_name",
-        "column_break_kzfw",
-        "transaction_date",
-        "required_by_date",
-        "sales_order",
-        "section_break_bzeq",
-        "price_list",
-        "status",
-        "amended_from",
-        "source_tab",
-        "section_break_lazn",
-        "source",
-        "project",
-        "quotation",
-        "type_of_case",
-        "items_tab",
-        "section_break_xhll",
-        "items",
-        "total_qty",
-        "total",
-        "taxes_tab",
-        "taxes_section_section",
-        "taxes_and_charges_template",
-        "taxes",
-        "advance_amount",
-        "balance_amount",
-        "total_taxes_and_charges",
-        "grand_total_section_section",
-        "grand_total"
-    ],
-    "fields": [
-        {
-            "fieldname": "channel_partner",
-            "fieldtype": "Link",
-            "label": "Channel Partner",
-            "options": "Channel Partner",
-            "reqd": 1
-        },
-        {
-            "fetch_from": "channel_partner.channel_partner_name",
-            "fieldname": "channel_partner_name",
-            "fieldtype": "Data",
-            "label": "Channel Partner Name",
-            "read_only": 1
-        },
-        {
-            "fieldname": "amended_from",
-            "fieldtype": "Link",
-            "label": "Amended From",
-            "no_copy": 1,
-            "options": "Channel Partner Purchase Order",
-            "print_hide": 1,
-            "read_only": 1,
-            "search_index": 1
-        },
-        {
-            "fieldname": "channel_partner_details_section",
-            "fieldtype": "Section Break"
-        },
-        {
-            "fieldname": "section_break_bzeq",
-            "fieldtype": "Section Break"
-        },
-        {
-            "default": "Draft",
-            "fieldname": "status",
-            "fieldtype": "Select",
-            "hidden": 1,
-            "in_list_view": 1,
-            "in_standard_filter": 1,
-            "label": "Status",
-            "options": "Draft\nSubmitted\nSO Created\nCancelled"
-        },
-        {
-            "fieldname": "column_break_kzfw",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "transaction_date",
-            "fieldtype": "Date",
-            "label": "Transaction Date"
-        },
-        {
-            "fieldname": "required_by_date",
-            "fieldtype": "Date",
-            "label": "Required By Date",
-            "reqd": 1
-        },
-        {
-            "fieldname": "sales_order",
-            "fieldtype": "Link",
-            "label": "Sales Order",
-            "options": "Sales Order",
-            "read_only": 1
-        },
-        {
-            "fieldname": "section_break_lazn",
-            "fieldtype": "Section Break"
-        },
-        {
-            "default": "Non Subsidy",
-            "fetch_from": "project.custom_type_of_case",
-            "fieldname": "type_of_case",
-            "fieldtype": "Select",
-            "label": "Type of Case",
-            "options": "\nSubsidy\nNon Subsidy\nNo Subsidy No Discom"
-        },
-        {
-            "depends_on": "eval:doc.source == \"Project\"",
-            "fieldname": "project",
-            "fieldtype": "Link",
-            "label": "Project",
-            "mandatory_depends_on": "eval:doc.source == \"Project\"",
-            "options": "Project"
-        },
-        {
-            "fieldname": "section_break_xhll",
-            "fieldtype": "Section Break"
-        },
-        {
-            "fieldname": "total_qty",
-            "fieldtype": "Float",
-            "label": "Total Quantity",
-            "read_only": 1
-        },
-        {
-            "fieldname": "items",
-            "fieldtype": "Table",
-            "label": "Items",
-            "options": "Channel Partner Purchase Order Item",
-            "reqd": 1
-        },
-        {
-            "fieldname": "total",
-            "fieldtype": "Currency",
-            "label": "Total",
-            "read_only": 1
-        },
-        {
-            "fieldname": "taxes_section_section",
-            "fieldtype": "Section Break"
-        },
-        {
-            "fieldname": "taxes_and_charges_template",
-            "fieldtype": "Link",
-            "label": "Taxes and Charges Template",
-            "options": "Sales Taxes and Charges Template"
-        },
-        {
-            "fieldname": "taxes",
-            "fieldtype": "Table",
-            "label": "Taxes",
-            "options": "Sales Taxes and Charges"
-        },
-        {
-            "fieldname": "total_taxes_and_charges",
-            "fieldtype": "Currency",
-            "label": "Total Taxes and Charges",
-            "read_only": 1
-        },
-        {
-            "fieldname": "grand_total_section_section",
-            "fieldtype": "Section Break",
-            "label": "Grand Total Section"
-        },
-        {
-            "fieldname": "grand_total",
-            "fieldtype": "Currency",
-            "in_list_view": 1,
-            "label": "Grand Total",
-            "read_only": 1
-        },
-        {
-            "fieldname": "channel_partner_tab",
-            "fieldtype": "Tab Break",
-            "label": "Channel Partner"
-        },
-        {
-            "depends_on": "eval:doc.channel_partner",
-            "fieldname": "items_tab",
-            "fieldtype": "Tab Break",
-            "label": "Items"
-        },
-        {
-            "depends_on": "eval:doc.channel_partner",
-            "fieldname": "taxes_tab",
-            "fieldtype": "Tab Break",
-            "label": "Taxes and Charges"
-        },
-        {
-            "fieldname": "advance_amount",
-            "fieldtype": "Currency",
-            "label": "Advance Amount"
-        },
-        {
-            "fieldname": "balance_amount",
-            "fieldtype": "Currency",
-            "label": "Balance Amount",
-            "read_only": 1
-        },
-        {
-            "depends_on": "eval:doc.source == \"Quotation\"",
-            "fieldname": "quotation",
-            "fieldtype": "Link",
-            "label": "Quotation",
-            "mandatory_depends_on": "eval:doc.source == \"Quotation\"",
-            "options": "Quotation"
-        },
-        {
-            "fieldname": "source",
-            "fieldtype": "Select",
-            "label": "Source",
-            "options": "\nProject\nQuotation\nManual Entry"
-        },
-        {
-            "fieldname": "source_tab",
-            "fieldtype": "Tab Break",
-            "hidden": 1,
-            "label": "Source"
-        },
-        {
-            "fieldname": "price_list",
-            "fieldtype": "Data",
-            "label": "Price List",
-            "read_only": 1
-        }
-    ],
-    "index_web_pages_for_search": 1,
-    "is_submittable": 1,
-    "links": [],
-    "modified": "2025-03-26 14:57:19.860532",
-    "modified_by": "Administrator",
-    "module": "Channel Partner",
-    "name": "Channel Partner Purchase Order",
-    "owner": "Administrator",
-    "permissions": [
-        {
-            "create": 1,
-            "email": 1,
-            "export": 1,
-            "print": 1,
-            "read": 1,
-            "report": 1,
-            "role": "Channel Partner",
-            "select": 1,
-            "share": 1,
-            "write": 1,
-            "submit": 1
-        },
-        {
-            "create": 1,
-            "delete": 1,
-            "email": 1,
-            "export": 1,
-            "print": 1,
-            "read": 1,
-            "report": 1,
-            "role": "Channel Partner Manager",
-            "select": 1,
-            "share": 1,
-            "write": 1,
-            "submit": 1
-        },
-        {
-            "create": 1,
-            "delete": 1,
-            "email": 1,
-            "export": 1,
-            "print": 1,
-            "read": 1,
-            "report": 1,
-            "role": "Sales Manager",
-            "select": 1,
-            "share": 1,
-            "submit": 1,
-            "write": 1
-        },
-        {
-            "create": 1,
-            "delete": 1,
-            "email": 1,
-            "export": 1,
-            "print": 1,
-            "read": 1,
-            "report": 1,
-            "role": "Accounts Manager",
-            "select": 1,
-            "share": 1,
-            "submit": 1,
-            "write": 1
-        }
-    ],
-    "quick_entry": 1,
-    "sort_field": "modified",
-    "sort_order": "DESC",
-    "states": [],
-    "track_changes": 1
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-03-10 11:39:10.630577",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "channel_partner_tab",
+  "channel_partner_details_section",
+  "channel_partner",
+  "channel_partner_name",
+  "column_break_kzfw",
+  "transaction_date",
+  "required_by_date",
+  "sales_order",
+  "section_break_bzeq",
+  "price_list",
+  "status",
+  "amended_from",
+  "source_tab",
+  "section_break_lazn",
+  "source",
+  "project",
+  "quotation",
+  "type_of_case",
+  "items_tab",
+  "section_break_xhll",
+  "items",
+  "total_qty",
+  "total",
+  "taxes_tab",
+  "taxes_section_section",
+  "taxes_and_charges_template",
+  "taxes",
+  "advance_amount",
+  "balance_amount",
+  "total_taxes_and_charges",
+  "grand_total_section_section",
+  "grand_total"
+ ],
+ "fields": [
+  {
+   "fieldname": "channel_partner",
+   "fieldtype": "Link",
+   "label": "Channel Partner",
+   "options": "Channel Partner",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "channel_partner.channel_partner_name",
+   "fieldname": "channel_partner_name",
+   "fieldtype": "Data",
+   "label": "Channel Partner Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Channel Partner Purchase Order",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "channel_partner_details_section",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_bzeq",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "Draft",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Draft\nSubmitted\nSO Created\nCancelled"
+  },
+  {
+   "fieldname": "column_break_kzfw",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "transaction_date",
+   "fieldtype": "Date",
+   "label": "Transaction Date"
+  },
+  {
+   "fieldname": "required_by_date",
+   "fieldtype": "Date",
+   "label": "Required By Date",
+   "reqd": 1
+  },
+  {
+   "fieldname": "sales_order",
+   "fieldtype": "Link",
+   "label": "Sales Order",
+   "options": "Sales Order",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_lazn",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "Non Subsidy",
+   "fetch_from": "project.custom_type_of_case",
+   "fieldname": "type_of_case",
+   "fieldtype": "Select",
+   "label": "Type of Case",
+   "options": "\nSubsidy\nNon Subsidy\nNo Subsidy No Discom"
+  },
+  {
+   "depends_on": "eval:doc.source == \"Project\"",
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "mandatory_depends_on": "eval:doc.source == \"Project\"",
+   "options": "Project"
+  },
+  {
+   "fieldname": "section_break_xhll",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "total_qty",
+   "fieldtype": "Float",
+   "label": "Total Quantity",
+   "read_only": 1
+  },
+  {
+   "fieldname": "items",
+   "fieldtype": "Table",
+   "label": "Items",
+   "options": "Channel Partner Purchase Order Item",
+   "reqd": 1
+  },
+  {
+   "fieldname": "total",
+   "fieldtype": "Currency",
+   "label": "Total",
+   "read_only": 1
+  },
+  {
+   "fieldname": "taxes_section_section",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "taxes_and_charges_template",
+   "fieldtype": "Link",
+   "label": "Taxes and Charges Template",
+   "options": "Sales Taxes and Charges Template",
+   "read_only": 1
+  },
+  {
+   "fieldname": "taxes",
+   "fieldtype": "Table",
+   "label": "Taxes",
+   "options": "Sales Taxes and Charges",
+   "read_only": 1
+  },
+  {
+   "fieldname": "total_taxes_and_charges",
+   "fieldtype": "Currency",
+   "label": "Total Taxes and Charges",
+   "read_only": 1
+  },
+  {
+   "fieldname": "grand_total_section_section",
+   "fieldtype": "Section Break",
+   "label": "Grand Total Section"
+  },
+  {
+   "fieldname": "grand_total",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Grand Total",
+   "read_only": 1
+  },
+  {
+   "fieldname": "channel_partner_tab",
+   "fieldtype": "Tab Break",
+   "label": "Channel Partner"
+  },
+  {
+   "depends_on": "eval:doc.channel_partner",
+   "fieldname": "items_tab",
+   "fieldtype": "Tab Break",
+   "label": "Items"
+  },
+  {
+   "depends_on": "eval:doc.channel_partner",
+   "fieldname": "taxes_tab",
+   "fieldtype": "Tab Break",
+   "label": "Taxes and Charges"
+  },
+  {
+   "fieldname": "advance_amount",
+   "fieldtype": "Currency",
+   "label": "Advance Amount"
+  },
+  {
+   "fieldname": "balance_amount",
+   "fieldtype": "Currency",
+   "label": "Balance Amount",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.source == \"Quotation\"",
+   "fieldname": "quotation",
+   "fieldtype": "Link",
+   "label": "Quotation",
+   "mandatory_depends_on": "eval:doc.source == \"Quotation\"",
+   "options": "Quotation"
+  },
+  {
+   "fieldname": "source",
+   "fieldtype": "Select",
+   "label": "Source",
+   "options": "\nProject\nQuotation\nManual Entry"
+  },
+  {
+   "fieldname": "source_tab",
+   "fieldtype": "Tab Break",
+   "hidden": 1,
+   "label": "Source"
+  },
+  {
+   "fieldname": "price_list",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Price List",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2025-03-31 13:20:20.784507",
+ "modified_by": "Administrator",
+ "module": "Channel Partner",
+ "name": "Channel Partner Purchase Order",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Channel Partner",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Channel Partner Manager",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "select": 1,
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "select": 1,
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
 }

--- a/suntek_app/channel_partner/doctype/channel_partner_purchase_order/channel_partner_purchase_order.json
+++ b/suntek_app/channel_partner/doctype/channel_partner_purchase_order/channel_partner_purchase_order.json
@@ -1,333 +1,308 @@
 {
- "actions": [],
- "allow_rename": 1,
- "creation": "2025-03-10 11:39:10.630577",
- "doctype": "DocType",
- "engine": "InnoDB",
- "field_order": [
-  "channel_partner_tab",
-  "channel_partner_details_section",
-  "channel_partner",
-  "channel_partner_name",
-  "column_break_kzfw",
-  "transaction_date",
-  "required_by_date",
-  "sales_order",
-  "section_break_bzeq",
-  "price_list",
-  "status",
-  "amended_from",
-  "source_tab",
-  "section_break_lazn",
-  "source",
-  "project",
-  "quotation",
-  "type_of_case",
-  "items_tab",
-  "section_break_xhll",
-  "items",
-  "total_qty",
-  "total",
-  "taxes_tab",
-  "taxes_section_section",
-  "taxes_and_charges_template",
-  "taxes",
-  "advance_amount",
-  "balance_amount",
-  "total_taxes_and_charges",
-  "grand_total_section_section",
-  "grand_total",
-  "terms_and_conditions_tab",
-  "terms_section_section",
-  "terms_and_conditions",
-  "terms_and_conditions_details"
- ],
- "fields": [
-  {
-   "fieldname": "channel_partner",
-   "fieldtype": "Link",
-   "label": "Channel Partner",
-   "options": "Channel Partner",
-   "reqd": 1
-  },
-  {
-   "fetch_from": "channel_partner.channel_partner_name",
-   "fieldname": "channel_partner_name",
-   "fieldtype": "Data",
-   "label": "Channel Partner Name",
-   "read_only": 1
-  },
-  {
-   "fieldname": "amended_from",
-   "fieldtype": "Link",
-   "label": "Amended From",
-   "no_copy": 1,
-   "options": "Channel Partner Purchase Order",
-   "print_hide": 1,
-   "read_only": 1,
-   "search_index": 1
-  },
-  {
-   "fieldname": "channel_partner_details_section",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "section_break_bzeq",
-   "fieldtype": "Section Break"
-  },
-  {
-   "default": "Draft",
-   "fieldname": "status",
-   "fieldtype": "Select",
-   "hidden": 1,
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Status",
-   "options": "Draft\nSubmitted\nSO Created\nCancelled"
-  },
-  {
-   "fieldname": "column_break_kzfw",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "transaction_date",
-   "fieldtype": "Date",
-   "label": "Transaction Date"
-  },
-  {
-   "fieldname": "required_by_date",
-   "fieldtype": "Date",
-   "label": "Required By Date",
-   "reqd": 1
-  },
-  {
-   "fieldname": "sales_order",
-   "fieldtype": "Link",
-   "label": "Sales Order",
-   "options": "Sales Order",
-   "read_only": 1
-  },
-  {
-   "fieldname": "section_break_lazn",
-   "fieldtype": "Section Break"
-  },
-  {
-   "default": "Non Subsidy",
-   "fetch_from": "project.custom_type_of_case",
-   "fieldname": "type_of_case",
-   "fieldtype": "Select",
-   "label": "Type of Case",
-   "options": "\nSubsidy\nNon Subsidy\nNo Subsidy No Discom"
-  },
-  {
-   "depends_on": "eval:doc.source == \"Project\"",
-   "fieldname": "project",
-   "fieldtype": "Link",
-   "label": "Project",
-   "mandatory_depends_on": "eval:doc.source == \"Project\"",
-   "options": "Project"
-  },
-  {
-   "fieldname": "section_break_xhll",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "total_qty",
-   "fieldtype": "Float",
-   "label": "Total Quantity",
-   "read_only": 1
-  },
-  {
-   "fieldname": "items",
-   "fieldtype": "Table",
-   "label": "Items",
-   "options": "Channel Partner Purchase Order Item",
-   "reqd": 1
-  },
-  {
-   "fieldname": "total",
-   "fieldtype": "Currency",
-   "label": "Total",
-   "read_only": 1
-  },
-  {
-   "fieldname": "taxes_section_section",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "taxes_and_charges_template",
-   "fieldtype": "Link",
-   "label": "Taxes and Charges Template",
-   "options": "Sales Taxes and Charges Template"
-  },
-  {
-   "fieldname": "taxes",
-   "fieldtype": "Table",
-   "label": "Taxes",
-   "options": "Sales Taxes and Charges"
-  },
-  {
-   "fieldname": "total_taxes_and_charges",
-   "fieldtype": "Currency",
-   "label": "Total Taxes and Charges",
-   "read_only": 1
-  },
-  {
-   "fieldname": "grand_total_section_section",
-   "fieldtype": "Section Break",
-   "label": "Grand Total Section"
-  },
-  {
-   "fieldname": "grand_total",
-   "fieldtype": "Currency",
-   "in_list_view": 1,
-   "label": "Grand Total",
-   "read_only": 1
-  },
-  {
-   "fieldname": "terms_section_section",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "terms_and_conditions",
-   "fieldtype": "Link",
-   "label": "Terms and Conditions",
-   "options": "Terms and Conditions"
-  },
-  {
-   "fetch_from": "terms_and_conditions.terms",
-   "fieldname": "terms_and_conditions_details",
-   "fieldtype": "Text Editor",
-   "label": "Terms and Conditions Details",
-   "no_copy": 1,
-   "read_only": 1
-  },
-  {
-   "fieldname": "channel_partner_tab",
-   "fieldtype": "Tab Break",
-   "label": "Channel Partner"
-  },
-  {
-   "depends_on": "eval:doc.channel_partner",
-   "fieldname": "items_tab",
-   "fieldtype": "Tab Break",
-   "label": "Items"
-  },
-  {
-   "depends_on": "eval:doc.channel_partner",
-   "fieldname": "taxes_tab",
-   "fieldtype": "Tab Break",
-   "label": "Taxes and Charges"
-  },
-  {
-   "fieldname": "terms_and_conditions_tab",
-   "fieldtype": "Tab Break",
-   "label": "Terms and Conditions"
-  },
-  {
-   "fieldname": "advance_amount",
-   "fieldtype": "Currency",
-   "label": "Advance Amount"
-  },
-  {
-   "fieldname": "balance_amount",
-   "fieldtype": "Currency",
-   "label": "Balance Amount",
-   "read_only": 1
-  },
-  {
-   "depends_on": "eval:doc.source == \"Quotation\"",
-   "fieldname": "quotation",
-   "fieldtype": "Link",
-   "label": "Quotation",
-   "mandatory_depends_on": "eval:doc.source == \"Quotation\"",
-   "options": "Quotation"
-  },
-  {
-   "fieldname": "source",
-   "fieldtype": "Select",
-   "label": "Source",
-   "options": "\nProject\nQuotation\nManual Entry"
-  },
-  {
-   "fieldname": "source_tab",
-   "fieldtype": "Tab Break",
-   "hidden": 1,
-   "label": "Source"
-  },
-  {
-   "fieldname": "price_list",
-   "fieldtype": "Data",
-   "label": "Price List",
-   "read_only": 1
-  }
- ],
- "index_web_pages_for_search": 1,
- "is_submittable": 1,
- "links": [],
- "modified": "2025-03-26 14:57:19.860532",
- "modified_by": "Administrator",
- "module": "Channel Partner",
- "name": "Channel Partner Purchase Order",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Channel Partner",
-   "select": 1,
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Channel Partner Manager",
-   "select": 1,
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Sales Manager",
-   "select": 1,
-   "share": 1,
-   "submit": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Accounts Manager",
-   "select": 1,
-   "share": 1,
-   "submit": 1,
-   "write": 1
-  }
- ],
- "quick_entry": 1,
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": [],
- "track_changes": 1
+    "actions": [],
+    "allow_rename": 1,
+    "creation": "2025-03-10 11:39:10.630577",
+    "doctype": "DocType",
+    "engine": "InnoDB",
+    "field_order": [
+        "channel_partner_tab",
+        "channel_partner_details_section",
+        "channel_partner",
+        "channel_partner_name",
+        "column_break_kzfw",
+        "transaction_date",
+        "required_by_date",
+        "sales_order",
+        "section_break_bzeq",
+        "price_list",
+        "status",
+        "amended_from",
+        "source_tab",
+        "section_break_lazn",
+        "source",
+        "project",
+        "quotation",
+        "type_of_case",
+        "items_tab",
+        "section_break_xhll",
+        "items",
+        "total_qty",
+        "total",
+        "taxes_tab",
+        "taxes_section_section",
+        "taxes_and_charges_template",
+        "taxes",
+        "advance_amount",
+        "balance_amount",
+        "total_taxes_and_charges",
+        "grand_total_section_section",
+        "grand_total"
+    ],
+    "fields": [
+        {
+            "fieldname": "channel_partner",
+            "fieldtype": "Link",
+            "label": "Channel Partner",
+            "options": "Channel Partner",
+            "reqd": 1
+        },
+        {
+            "fetch_from": "channel_partner.channel_partner_name",
+            "fieldname": "channel_partner_name",
+            "fieldtype": "Data",
+            "label": "Channel Partner Name",
+            "read_only": 1
+        },
+        {
+            "fieldname": "amended_from",
+            "fieldtype": "Link",
+            "label": "Amended From",
+            "no_copy": 1,
+            "options": "Channel Partner Purchase Order",
+            "print_hide": 1,
+            "read_only": 1,
+            "search_index": 1
+        },
+        {
+            "fieldname": "channel_partner_details_section",
+            "fieldtype": "Section Break"
+        },
+        {
+            "fieldname": "section_break_bzeq",
+            "fieldtype": "Section Break"
+        },
+        {
+            "default": "Draft",
+            "fieldname": "status",
+            "fieldtype": "Select",
+            "hidden": 1,
+            "in_list_view": 1,
+            "in_standard_filter": 1,
+            "label": "Status",
+            "options": "Draft\nSubmitted\nSO Created\nCancelled"
+        },
+        {
+            "fieldname": "column_break_kzfw",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "transaction_date",
+            "fieldtype": "Date",
+            "label": "Transaction Date"
+        },
+        {
+            "fieldname": "required_by_date",
+            "fieldtype": "Date",
+            "label": "Required By Date",
+            "reqd": 1
+        },
+        {
+            "fieldname": "sales_order",
+            "fieldtype": "Link",
+            "label": "Sales Order",
+            "options": "Sales Order",
+            "read_only": 1
+        },
+        {
+            "fieldname": "section_break_lazn",
+            "fieldtype": "Section Break"
+        },
+        {
+            "default": "Non Subsidy",
+            "fetch_from": "project.custom_type_of_case",
+            "fieldname": "type_of_case",
+            "fieldtype": "Select",
+            "label": "Type of Case",
+            "options": "\nSubsidy\nNon Subsidy\nNo Subsidy No Discom"
+        },
+        {
+            "depends_on": "eval:doc.source == \"Project\"",
+            "fieldname": "project",
+            "fieldtype": "Link",
+            "label": "Project",
+            "mandatory_depends_on": "eval:doc.source == \"Project\"",
+            "options": "Project"
+        },
+        {
+            "fieldname": "section_break_xhll",
+            "fieldtype": "Section Break"
+        },
+        {
+            "fieldname": "total_qty",
+            "fieldtype": "Float",
+            "label": "Total Quantity",
+            "read_only": 1
+        },
+        {
+            "fieldname": "items",
+            "fieldtype": "Table",
+            "label": "Items",
+            "options": "Channel Partner Purchase Order Item",
+            "reqd": 1
+        },
+        {
+            "fieldname": "total",
+            "fieldtype": "Currency",
+            "label": "Total",
+            "read_only": 1
+        },
+        {
+            "fieldname": "taxes_section_section",
+            "fieldtype": "Section Break"
+        },
+        {
+            "fieldname": "taxes_and_charges_template",
+            "fieldtype": "Link",
+            "label": "Taxes and Charges Template",
+            "options": "Sales Taxes and Charges Template"
+        },
+        {
+            "fieldname": "taxes",
+            "fieldtype": "Table",
+            "label": "Taxes",
+            "options": "Sales Taxes and Charges"
+        },
+        {
+            "fieldname": "total_taxes_and_charges",
+            "fieldtype": "Currency",
+            "label": "Total Taxes and Charges",
+            "read_only": 1
+        },
+        {
+            "fieldname": "grand_total_section_section",
+            "fieldtype": "Section Break",
+            "label": "Grand Total Section"
+        },
+        {
+            "fieldname": "grand_total",
+            "fieldtype": "Currency",
+            "in_list_view": 1,
+            "label": "Grand Total",
+            "read_only": 1
+        },
+        {
+            "fieldname": "channel_partner_tab",
+            "fieldtype": "Tab Break",
+            "label": "Channel Partner"
+        },
+        {
+            "depends_on": "eval:doc.channel_partner",
+            "fieldname": "items_tab",
+            "fieldtype": "Tab Break",
+            "label": "Items"
+        },
+        {
+            "depends_on": "eval:doc.channel_partner",
+            "fieldname": "taxes_tab",
+            "fieldtype": "Tab Break",
+            "label": "Taxes and Charges"
+        },
+        {
+            "fieldname": "advance_amount",
+            "fieldtype": "Currency",
+            "label": "Advance Amount"
+        },
+        {
+            "fieldname": "balance_amount",
+            "fieldtype": "Currency",
+            "label": "Balance Amount",
+            "read_only": 1
+        },
+        {
+            "depends_on": "eval:doc.source == \"Quotation\"",
+            "fieldname": "quotation",
+            "fieldtype": "Link",
+            "label": "Quotation",
+            "mandatory_depends_on": "eval:doc.source == \"Quotation\"",
+            "options": "Quotation"
+        },
+        {
+            "fieldname": "source",
+            "fieldtype": "Select",
+            "label": "Source",
+            "options": "\nProject\nQuotation\nManual Entry"
+        },
+        {
+            "fieldname": "source_tab",
+            "fieldtype": "Tab Break",
+            "hidden": 1,
+            "label": "Source"
+        },
+        {
+            "fieldname": "price_list",
+            "fieldtype": "Data",
+            "label": "Price List",
+            "read_only": 1
+        }
+    ],
+    "index_web_pages_for_search": 1,
+    "is_submittable": 1,
+    "links": [],
+    "modified": "2025-03-26 14:57:19.860532",
+    "modified_by": "Administrator",
+    "module": "Channel Partner",
+    "name": "Channel Partner Purchase Order",
+    "owner": "Administrator",
+    "permissions": [
+        {
+            "create": 1,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "Channel Partner",
+            "select": 1,
+            "share": 1,
+            "write": 1,
+            "submit": 1
+        },
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "Channel Partner Manager",
+            "select": 1,
+            "share": 1,
+            "write": 1,
+            "submit": 1
+        },
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "Sales Manager",
+            "select": 1,
+            "share": 1,
+            "submit": 1,
+            "write": 1
+        },
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "Accounts Manager",
+            "select": 1,
+            "share": 1,
+            "submit": 1,
+            "write": 1
+        }
+    ],
+    "quick_entry": 1,
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "states": [],
+    "track_changes": 1
 }

--- a/suntek_app/channel_partner/doctype/channel_partner_purchase_order/channel_partner_purchase_order.py
+++ b/suntek_app/channel_partner/doctype/channel_partner_purchase_order/channel_partner_purchase_order.py
@@ -28,6 +28,7 @@ class ChannelPartnerPurchaseOrder(Document):
         self.validate_channel_partner()
         self.validate_type_of_case()
         self.fetch_type_of_case_from_project()
+        self.set_tax_template_from_firm()
         self.calculate_totals()
         self.update_status()
 
@@ -68,6 +69,15 @@ class ChannelPartnerPurchaseOrder(Document):
             type_of_case = frappe.db.get_value("Project", self.project, "custom_type_of_case")
             if type_of_case:
                 self.type_of_case = type_of_case
+
+    def set_tax_template_from_firm(self):
+        """Set tax template from channel partner firm if not already set"""
+        if not self.taxes_and_charges_template and self.channel_partner:
+            channel_partner = frappe.get_doc("Channel Partner", self.channel_partner)
+            if channel_partner.channel_partner_firm:
+                firm = frappe.get_doc("Channel Partner Firm", channel_partner.channel_partner_firm)
+                if firm.taxes_and_charges_template:
+                    self.taxes_and_charges_template = firm.taxes_and_charges_template
 
     def calculate_totals(self):
         """Calculate total quantity, amount, taxes and grand total"""

--- a/suntek_app/fixtures/module_profile.json
+++ b/suntek_app/fixtures/module_profile.json
@@ -1,0 +1,257 @@
+[
+ {
+  "block_modules": [
+   {
+    "module": "Accounts",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Assets",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Audit Trail",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Automation",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Bulk Transaction",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Buying",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Communication",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Contacts",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "CRM (Tele-Calling)",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Custom",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "E-commerce",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "EDI",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Email",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Employee Self Service",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "ERPNext Integrations",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Frappe Whatsapp",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Geo",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "GST India",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "HR",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Income Tax India",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Integrations",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Maintenance",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Manufacturing",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Payment Gateways",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Payments",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Payroll",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Portal",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Printing",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Projects",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Quality Management",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Refer & Earn",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Regional",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Selling",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Social",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Subcontracting",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Support",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Telephony",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Utilities",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "VAT India",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Website",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   },
+   {
+    "module": "Workflow",
+    "parent": "Channel Partner",
+    "parentfield": "block_modules",
+    "parenttype": "Module Profile"
+   }
+  ],
+  "docstatus": 0,
+  "doctype": "Module Profile",
+  "modified": "2025-03-31 13:12:39.117510",
+  "module_profile_name": "Channel Partner",
+  "name": "Channel Partner"
+ }
+]

--- a/suntek_app/hooks.py
+++ b/suntek_app/hooks.py
@@ -169,6 +169,8 @@ fixtures = [
     },
     {
         "doctype": "Module Profile",
-        "filters": [["name", "=", "Channel Partner"]],
+        "filters": [
+            ["name", "=", "Channel Partner"],
+        ],
     },
 ]

--- a/suntek_app/hooks.py
+++ b/suntek_app/hooks.py
@@ -167,4 +167,8 @@ fixtures = [
         "doctype": "Property Setter",
         "filters": [["name", "in", ["Sales Order-order_type-options"]]],
     },
+    {
+        "doctype": "Module Profile",
+        "filters": [["name", "=", "Channel Partner"]],
+    },
 ]


### PR DESCRIPTION
- Updated the `Channel Partner` and `Channel Partner Firm` JavaScript files to improve readability and maintainability.
- Added a new method `create_sales_partner` in `Channel Partner Firm` to create sales partners in the name of the Firm.
- Removed unnecessary comments and optimized existing code for better performance.
- Export Module Profile "Channel Partner" to fixtures.
- Prefetch Tax templates from the Firm into the Channel Partner Purchase Order