### PR TITLE
Fix(Sales Order): Delete Project and other documents linked to Sales Order

### DIFF
--- a/suntek_app/hooks.py
+++ b/suntek_app/hooks.py
@@ -119,6 +119,7 @@ doc_events = {
         "after_save": [
             "suntek_app.event_handlers.sales_order_event_handler.update_cppo_from_sales_order",
         ],
+        "on_cancel": "suntek_app.suntek.custom.sales_order.delete_linked_documents_on_cancel",
     },
     "Project": {
         "validate": "suntek_app.suntek.custom.project.validate",

--- a/suntek_app/hooks.py
+++ b/suntek_app/hooks.py
@@ -111,7 +111,6 @@ doc_events = {
         ],
     },
     "Sales Order": {
-        "on_submit": "suntek_app.suntek.custom.sales_order.auto_project_creation_on_submit",
         "on_update": [
             "suntek_app.api.webhook_handler.send_ambassador_status_update",
             "suntek_app.event_handlers.sales_order_event_handler.update_cppo_from_sales_order",
@@ -119,7 +118,12 @@ doc_events = {
         "after_save": [
             "suntek_app.event_handlers.sales_order_event_handler.update_cppo_from_sales_order",
         ],
-        "on_cancel": "suntek_app.suntek.custom.sales_order.delete_linked_documents_on_cancel",
+        "before_submit": [
+            "suntek_app.suntek.custom.sales_order.create_project_discom_subsidy_before_submit",
+        ],
+        "on_cancel": [
+            "suntek_app.suntek.custom.sales_order.delete_linked_documents_on_cancel",  # Cancel Project, Subsidy, Discom linked to Sales Order
+        ],
     },
     "Project": {
         "validate": "suntek_app.suntek.custom.project.validate",

--- a/suntek_app/suntek/custom/sales_order.py
+++ b/suntek_app/suntek/custom/sales_order.py
@@ -24,6 +24,24 @@ def auto_project_creation_on_submit(doc, method):
     update_opportunity(doc)
 
 
+@frappe.whitelist()
+def delete_linked_documents_on_cancel(doc, method):
+    """Delete linked documents when a sales order is cancelled."""
+    if doc.docstatus == 2:
+        projects = frappe.get_all("Project", filters={"sales_order": doc.name}, fields=["name"])
+
+        for project in projects:
+            subsidies = frappe.get_all("Subsidy", filters={"project_name": project.name}, fields=["name"])
+            for subsidy in subsidies:
+                frappe.delete_doc("Subsidy", subsidy.name, force=1)
+
+            discoms = frappe.get_all("Discom", filters={"project_name": project.name}, fields=["name"])
+            for discom in discoms:
+                frappe.delete_doc("Discom", discom.name, force=1)
+
+            frappe.delete_doc("Project", project.name, force=1)
+
+
 def create_discom(project):
     """Creates Discom record based on the project's custom type of case."""
 

--- a/suntek_app/suntek/custom/sales_order.py
+++ b/suntek_app/suntek/custom/sales_order.py
@@ -1,8 +1,30 @@
 import frappe
 
 
+def create_project_discom_subsidy_before_submit(doc, method):
+    if frappe.db.exists("Project", {"project_name": doc.name}):
+        _delete_documents_linked_to_sales_order(doc)
+
+    new_project = make_project(doc)
+    new_project.custom_poc_person_name = doc.custom_person_name
+    new_project.custom_poc_mobile_no = doc.custom_another_mobile_no
+    new_project.save()
+
+    if doc.custom_type_of_case == "Subsidy":
+        create_subsidy(new_project)
+        create_discom(new_project)
+    elif doc.custom_type_of_case == "Discom":
+        create_discom(new_project)
+
+    doc.project = new_project.name
+
+    frappe.db.set_value("Sales Order", doc.name, "project", new_project.name, update_modified=False)
+
+    update_opportunity(doc)
+
+
 @frappe.whitelist()
-def auto_project_creation_on_submit(doc, method):
+def auto_project_creation_on_submit(doc, method):  # Deprecated
     if doc.docstatus == 1 and not doc.amended_from:
         project_make = None
         if not frappe.db.exists("Project", {"project_name": doc.name}):
@@ -28,18 +50,21 @@ def auto_project_creation_on_submit(doc, method):
 def delete_linked_documents_on_cancel(doc, method):
     """Delete linked documents when a sales order is cancelled."""
     if doc.docstatus == 2:
-        projects = frappe.get_all("Project", filters={"sales_order": doc.name}, fields=["name"])
+        _delete_documents_linked_to_sales_order(doc)
 
-        for project in projects:
-            subsidies = frappe.get_all("Subsidy", filters={"project_name": project.name}, fields=["name"])
-            for subsidy in subsidies:
-                frappe.delete_doc("Subsidy", subsidy.name, force=1)
 
-            discoms = frappe.get_all("Discom", filters={"project_name": project.name}, fields=["name"])
-            for discom in discoms:
-                frappe.delete_doc("Discom", discom.name, force=1)
+def _delete_documents_linked_to_sales_order(doc):
+    projects = frappe.get_all("Project", filters={"sales_order": doc.name}, fields=["name"])
 
-            frappe.delete_doc("Project", project.name, force=1)
+    for project in projects:
+        subsidies = frappe.get_all("Subsidy", filters={"project_name": project.name}, fields=["name"])
+        discoms = frappe.get_all("Discom", filters={"project_name": project.name}, fields=["name"])
+
+        for subsidy in subsidies:
+            frappe.delete_doc("Subsidy", subsidy.name, force=1)
+        for discom in discoms:
+            frappe.delete_doc("Discom", discom.name, force=1)
+        doc.db_set("project", None)
 
 
 def create_discom(project):
@@ -112,9 +137,8 @@ def get_location_data(doc, method):
 
 def fetch_attachments_from_opportunity(doc, method):
     if doc.custom_opportunity_name != "":
-        print("doc.custom_opportunity_name: ", doc.custom_opportunity_name)
         opportunity = frappe.get_doc("Opportunity", {"name": doc.custom_opportunity_name})
-        print(opportunity)
+
         opportunity_attachments = frappe.get_all(
             "File",
             filters={
@@ -148,7 +172,6 @@ def fetch_attachments_from_opportunity(doc, method):
 
                     opportunity_attachment.insert()
                     opportunity_attachment.reload()
-                    print("opportunity_attachment: ", opportunity_attachment)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
This pull request introduces a new feature to handle the deletion of linked documents when a sales order is canceled. The most significant changes include adding a new hook for the `on_cancel` event and implementing the logic to delete linked documents such as `Project`, `Subsidy`, and `Discom`.

### New functionality for handling cancellations:

* **Hook addition**: Added an `on_cancel` hook in `suntek_app/hooks.py` to trigger the `delete_linked_documents_on_cancel` function when a sales order is canceled.
* **Function implementation**: Introduced the `delete_linked_documents_on_cancel` function in `suntek_app/suntek/custom/sales_order.py`. This function checks if the sales order is canceled (`docstatus == 2`) and deletes associated `Project`, `Subsidy`, and `Discom` records.