### PR TITLE
fix: grant ess role and module to users

### DIFF
--- a/suntek_app/patches.txt
+++ b/suntek_app/patches.txt
@@ -11,6 +11,7 @@ suntek_app.patches.change_module_of_ambassador_doctype
 suntek_app.patches.remove_duplicate_permissions
 suntek_app.patches.change_ambassador_module_def
 suntek_app.patches.share_unshared_leads_from_just_dial_and_ambassador
+suntek_app.patches.grant_ess_role_and_module
 
 [post_model_sync]
 suntek_app.patches.close_or_hold_sales_orders

--- a/suntek_app/patches/grant_ess_role_and_module.py
+++ b/suntek_app/patches/grant_ess_role_and_module.py
@@ -1,0 +1,86 @@
+import frappe
+
+
+def execute():
+    module_name = "Employee Self Service"
+    role_name = "Employee Self Service"
+
+    log_message = f"Starting to add '{module_name}' module and '{role_name}' role to eligible users"
+    print(log_message)
+    frappe.log_error(log_message, "Employee Self Service Access Update")
+
+    if not frappe.db.exists("Role", role_name):
+        error_message = f"Role '{role_name}' does not exist in the system. Patch cannot continue."
+        print(error_message)
+        frappe.log_error(error_message, "Employee Self Service Access Update Error")
+        return {"status": "error", "message": error_message}
+
+    module_updated_count = 0
+    role_updated_count = 0
+    skipped_count = 0
+
+    users = frappe.get_all(
+        "User", filters={"enabled": 1, "user_type": "System User"}, fields=["name", "email", "full_name"]
+    )
+
+    for user in users:
+        try:
+            is_employee = frappe.db.exists("Employee", {"user_id": user.name, "status": "Active"})
+
+            if not is_employee:
+                skipped_count += 1
+                continue
+
+            user_doc = frappe.get_doc("User", user.name)
+            changes_made = False
+
+            blocked_modules = frappe.get_all(
+                "Block Module", filters={"parent": user.name, "module": module_name}, fields=["name"]
+            )
+
+            if blocked_modules:
+                for blocked in blocked_modules:
+                    frappe.db.delete("Block Module", blocked.name)
+                changes_made = True
+                module_updated_count += 1
+                print(f"Unblocked '{module_name}' module for user: {user.name}")
+
+            has_role = False
+            for role in user_doc.roles:
+                if role.role == role_name:
+                    has_role = True
+                    break
+
+            if not has_role:
+                user_doc.append("roles", {"role": role_name})
+                user_doc.save()
+                changes_made = True
+                role_updated_count += 1
+                print(f"Added '{role_name}' role to user: {user.name}")
+
+            if changes_made:
+                frappe.db.commit()
+
+        except Exception as e:
+            frappe.db.rollback()
+            error_message = f"Failed to update access for user {user.name}: {str(e)}"
+            print(error_message)
+            frappe.log_error(error_message, "Employee Self Service Access Update Error")
+
+    completion_message = f"""
+    Employee Self Service Access Update Complete:
+    - Total users processed: {len(users)}
+    - Skipped (not employees): {skipped_count}
+    - Module unblocked for: {module_updated_count} users
+    - Role added to: {role_updated_count} users
+    """
+
+    print(completion_message)
+    frappe.log_error(completion_message, "Employee Self Service Access Update Complete")
+
+    return {
+        "total_users": len(users),
+        "skipped_users": skipped_count,
+        "module_updates": module_updated_count,
+        "role_updates": role_updated_count,
+    }


### PR DESCRIPTION
This pull request introduces a new patch to the `suntek_app` application that grants the "Employee Self Service" role and unblocks the corresponding module for eligible users. The changes include adding the patch to the patch sequence and implementing the logic to handle the role and module updates.

### Patch Addition:
* Added `suntek_app.patches.grant_ess_role_and_module` to the patch sequence in `suntek_app/patches.txt`. This ensures the new patch is executed as part of the application's update process.

### Implementation of the New Patch:
* Created the `grant_ess_role_and_module.py` script to:
  - Check if the "Employee Self Service" role exists in the system.
  - Process all enabled system users and determine if they are active employees.
  - Unblock the "Employee Self Service" module for eligible users by removing any existing "Block Module" entries.
  - Add the "Employee Self Service" role to eligible users if it is not already assigned.
  - Log detailed messages for each step, including success, errors, and completion summaries.