### PR TITLE
Fix(Permissions) - Explicitly set doctype before searching for subordinate permissions

### DIFF
--- a/suntek_app/permissions/__init__.py
+++ b/suntek_app/permissions/__init__.py
@@ -81,7 +81,8 @@ def base_permission_query_conditions(user, doctype, special_owner_field=None):
                            AND `tabToDo`.reference_name = `tab{doctype}`.name
                            AND `tabToDo`.owner = {frappe.db.escape(user)})"""
 
-    owner_condition = f"`owner` = {frappe.db.escape(user)}"
+    # owner_condition = f"`owner` = {frappe.db.escape(user)}"
+    owner_condition = f"`tab{doctype}`.`owner` = {frappe.db.escape(user)}"
 
     special_owner_condition = ""
     if special_owner_field:
@@ -114,7 +115,8 @@ def get_subordinate_conditions(user, doctype, special_owner_field=None):
 
     if subordinate_users:
         quoted_users = [frappe.db.escape(u) for u in subordinate_users]
-        subordinate_conditions.append(f"`owner` in ({', '.join(quoted_users)})")
+        # subordinate_conditions.append(f"`owner` in ({', '.join(quoted_users)})")
+        subordinate_conditions.append(f"`tab{doctype}`.`owner` in ({', '.join(quoted_users)})")
 
     if special_owner_field and subordinate_users:
         quoted_users = [frappe.db.escape(u) for u in subordinate_users]


### PR DESCRIPTION
This pull request updates the permission query logic in `suntek_app/permissions/__init__.py` to ensure that the `owner` field is explicitly scoped to the relevant table (`tab{doctype}`). This change improves query clarity and prevents potential ambiguities when dealing with multiple tables.

### Changes to permission query logic:

* **Scoped `owner` field in `base_permission_query_conditions`:** Updated the `owner_condition` to reference the `owner` field explicitly as `tab{doctype}.owner` instead of just `owner`. The previous condition was commented out for clarity.
* **Scoped `owner` field in `get_subordinate_conditions`:** Modified the `subordinate_conditions` to explicitly scope the `owner` field as `tab{doctype}.owner`. The earlier condition was also commented out.